### PR TITLE
Added Tabs for Xacml Management

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -33,6 +33,38 @@ function islandora_xacml_editor_menu() {
 }
 
 /**
+ * Implementation of hook_islandora_tabs().
+ */
+function islandora_xacml_islandora_tabs($content_models, $pid) {
+  $tabs = array();
+  if (user_access('Edit XACML Policies')) {
+    $item_is_collection = FALSE;
+    foreach ($content_models as $content_model) {
+      if ($content_model->pid == 'islandora:collectionCModel') {
+        $item_is_collection = TRUE;
+        break;
+      }
+    }
+    if ($item_is_collection) {
+      $title = t('Child Policy');
+      $dsid = 'CHILD_POLICY';
+    }
+    else {
+      $title = t('Policy');
+      $dsid = 'POLICY';
+    }
+    if ($item_is_collection) {
+      $tabs['xacml_policy'] = array(
+        '#type' => 'tabpage',
+        '#title' => $title,
+        '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid), 
+      )
+    }
+  }
+  return $tabs;
+}
+
+/**
  * The XACML editing form.
  */
 function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -35,7 +35,7 @@ function islandora_xacml_editor_menu() {
 /**
  * Implementation of hook_islandora_tabs().
  */
-function islandora_xacml_islandora_tabs($content_models, $pid) {
+function islandora_xacml_editor_islandora_tabs($content_models, $pid) {
   $tabs = array();
   if (user_access('Edit XACML Policies')) {
     $item_is_collection = FALSE;
@@ -50,16 +50,14 @@ function islandora_xacml_islandora_tabs($content_models, $pid) {
       $dsid = 'CHILD_POLICY';
     }
     else {
-      $title = t('Policy');
+      $title = t('Item Policy');
       $dsid = 'POLICY';
     }
-    if ($item_is_collection) {
-      $tabs['xacml_policy'] = array(
-        '#type' => 'tabpage',
-        '#title' => $title,
-        '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid), 
-      )
-    }
+    $tabs['xacml_policy'] = array(
+      '#type' => 'tabpage',
+      '#title' => $title,
+      '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid), 
+    );
   }
   return $tabs;
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -10,7 +10,7 @@
  * Implementation of hook_perm().
  */
 function islandora_xacml_editor_perm() {
-  return array('Edit XACML Policies');
+  return array('administer islandora_xacml_editor', 'Edit XACML Policies');
 }
 
 /**
@@ -28,6 +28,14 @@ function islandora_xacml_editor_menu() {
     'page arguments' => array('islandora_xacml_editor_page',1,2),
     'access arguments' => array('Edit XACML Policies'),
   );
+  
+  $items['admin/settings/islandora_xacml_editor'] = array(
+    'title' => 'Islandora XACML Editor',
+    'description' => 'Settings for the Islandora XACML module.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_xacml_editor_settings'),
+    'access arguments' => array('administer islandora_xacml_editor'),
+  );
 
   return $items;
 }
@@ -37,29 +45,45 @@ function islandora_xacml_editor_menu() {
  */
 function islandora_xacml_editor_islandora_tabs($content_models, $pid) {
   $tabs = array();
-  if (user_access('Edit XACML Policies')) {
-    $item_is_collection = FALSE;
-    foreach ($content_models as $content_model) {
-      if ($content_model->pid == 'islandora:collectionCModel') {
-        $item_is_collection = TRUE;
-        break;
+  if (variable_get('islandora_xacml_editor_show_tabs', FALSE)) {
+    if (user_access('Edit XACML Policies')) {
+      $item_is_collection = FALSE;
+      foreach ($content_models as $content_model) {
+        if ($content_model->pid == 'islandora:collectionCModel') {
+          $item_is_collection = TRUE;
+          break;
+        }
       }
+      if ($item_is_collection) {
+        $title = t('Child Policy');
+        $dsid = 'CHILD_SECURITY';
+      }
+      else {
+        $title = t('Item Policy');
+        $dsid = 'POLICY';
+      }
+      $tabs['xacml_policy'] = array(
+        '#type' => 'tabpage',
+        '#title' => $title,
+        '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid), 
+      );
     }
-    if ($item_is_collection) {
-      $title = t('Child Policy');
-      $dsid = 'CHILD_SECURITY';
-    }
-    else {
-      $title = t('Item Policy');
-      $dsid = 'POLICY';
-    }
-    $tabs['xacml_policy'] = array(
-      '#type' => 'tabpage',
-      '#title' => $title,
-      '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid), 
-    );
   }
   return $tabs;
+}
+
+/**
+ * Admin settings form.
+ */
+function islandora_xacml_editor_settings() {
+  $form = array();
+  $form['islandora_xacml_editor_show_tabs'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show Policy Tabs'),
+    '#description' => t('Show a tab for the XACML Policy Editor on each Fedora item\'s page. For normal items, this policy will only apply to the item itself; in the case of collection items (having the content model &lt;islandora:collectionCModel&gt;), this will be a child policy.'),
+    '#default_value' => variable_get('islandora_xacml_editor_show_tabs',0),
+  );
+  return system_settings_form($form);
 }
 
 /**

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -47,7 +47,7 @@ function islandora_xacml_editor_islandora_tabs($content_models, $pid) {
     }
     if ($item_is_collection) {
       $title = t('Child Policy');
-      $dsid = 'CHILD_POLICY';
+      $dsid = 'CHILD_SECURITY';
     }
     else {
       $title = t('Item Policy');

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -45,7 +45,7 @@ function islandora_xacml_editor_menu() {
  */
 function islandora_xacml_editor_islandora_tabs($content_models, $pid) {
   $tabs = array();
-  if (variable_get('islandora_xacml_editor_show_tabs', FALSE)) {
+  if (variable_get('islandora_xacml_editor_show_tabs', TRUE)) {
     if (user_access('Edit XACML Policies')) {
       $item_is_collection = FALSE;
       foreach ($content_models as $content_model) {
@@ -80,8 +80,8 @@ function islandora_xacml_editor_settings() {
   $form['islandora_xacml_editor_show_tabs'] = array(
     '#type' => 'checkbox',
     '#title' => t('Show Policy Tabs'),
-    '#description' => t('Show a tab for the XACML Policy Editor on each Fedora item\'s page. For normal items, this policy will only apply to the item itself; in the case of collection items (having the content model &lt;islandora:collectionCModel&gt;), this will be a child policy.'),
-    '#default_value' => variable_get('islandora_xacml_editor_show_tabs',0),
+    '#description' => t("Show a tab for the XACML Policy Editor on each Fedora item's page. For normal items, this policy will only apply to the item itself; in the case of collection items (having the content model &lt;islandora:collectionCModel&gt;), this will be a child policy."),
+    '#default_value' => variable_get('islandora_xacml_editor_show_tabs',1),
   );
   return system_settings_form($form);
 }


### PR DESCRIPTION
The original editor didn't have any tabs by default, so the XACML editor was hard to find. This commit adds tabs to the default Islandora interface, while keeping the menupath so that it can be accessed directly. This commit also adds a simple admin interface, allowing tabs to be turned off if needed.
