### PR TITLE
Added the mimetypes from the content model to GUI

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -66,6 +66,37 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
 
   $mime = array();
   $dsid = array();
+
+
+  module_load_include('inc', 'fedora_repository', 'ContentModel');
+
+  if($xacml_dsid == 'CHILD_SECURITY') {
+    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');  
+
+    $collection = CollectionPolicy::loadFromCollection($object_pid);
+    if($collection) {
+      $cms = $collection->getContentModels();
+      foreach($cms as $cm) {
+        $contentmodel = ContentModel::loadFromModel($cm->pid);
+        if($contentmodel) {
+          $tmp = $contentmodel->getMimetypes();
+          foreach($tmp as $t) {
+            $mime[$t] = $t;
+          }
+        }
+      }
+    }
+  }
+  else {
+    $contentmodel = ContentModel::loadFromObject($object_pid);
+    if($contentmodel) {
+      $tmp = $contentmodel->getMimetypes();
+      foreach($tmp as $t) {
+        $mime[$t] = $t;
+      }
+    }
+  }
+
   foreach($datastreams as $k => $ds) {
     $mime[$ds['MIMEType']] = $ds['MIMEType'];
     $dsid[$k] = $k;


### PR DESCRIPTION
Added the mimetypes from the content model to GUI  The GUI for editing XACML used to only display the mimetypes that were part of the object already. I added mimetypes to that the mimetypes that are listed in the content model, so that you can lock out objects before they are added.
