### PR TITLE
cleaned up loads of drupal coding style problems

### DIFF
--- a/api/Xacml.inc
+++ b/api/Xacml.inc
@@ -41,6 +41,7 @@ abstract class XacmlRule {
    *   Takes the ID for the new rule as a string.
    * @param $effect
    *   The effect of the rule (Permit or Deny)
+   *
    * @return array
    *   A structure that is parsable by XacmlWriter.
    */
@@ -62,13 +63,13 @@ abstract class XacmlRule {
   /**
    * Helper function. Allows strings or arrays of strings to be passed in.
    *
-   * @param $type
+   * @param String $type
    *   Array key to modify in internal $rules datastructure.
    * @param $data
    *   Data to be added.
    */
   protected function setValue($type, $data) {
-    if(is_array($data)) {
+    if (is_array($data)) {
       $this->rule[$type] = array_merge($this->rule[$type], array_values($data));
     }
     else {
@@ -79,8 +80,9 @@ abstract class XacmlRule {
   /**
    * Helper function. Internal arrays may have repeated values. Fixes this before returning.
    *
-   * @param $type
+   * @param String $type
    *   Array key in internal datastructure to return
+   *
    * @return
    *   Array requested.
    */
@@ -92,17 +94,18 @@ abstract class XacmlRule {
    * Uses the array_diff functionality to remove data from internal rule representation.
    *
    * @todo This could all be made more efficient.
-   * @param $type
+   *
+   * @param String $type
    *   Array key to work on
    * @param $data
    *   Data to be removed.
    */
   protected function removeValues($type, $data) {
-    if(!is_array($data)) {
+    if (!is_array($data)) {
       $data = array($data);
     }
 
-    $this->rule[$type] = array_diff($this->rule[$type],$data);
+    $this->rule[$type] = array_diff($this->rule[$type], $data);
   }
 
   /**
@@ -119,7 +122,7 @@ abstract class XacmlRule {
    *   reference to the XACML object that this datastructure is part of.
    */
   function __construct($arg1, $xacml) {
-    if(is_array($arg1)) {
+    if (is_array($arg1)) {
       $this->rule = $arg1;
       /* remove them now, add them later */
       $this->setValue('users', 'fedoraAdmin');
@@ -151,20 +154,20 @@ abstract class XacmlRule {
    *   An array of strings containing the roles being tested. Or NULL.
    */
   function hasPermission($user, $roles = NULL, $default = TRUE) {
-    // we always allow the administrator role
-    if(in_array('administrator', $roles)) {
+    // We always allow the administrator role.
+    if (in_array('administrator', $roles)) {
       return TRUE;
     }
 
     // if the rule is not populated we return the default value
-    if(!$this->isPopulated()) {
+    if (!$this->isPopulated()) {
       return $default;
     }
 
     // otherwise we see if they are allowed
-    $boolean_user = in_array($user,$this->getUsers());
-    $boolean_role = array_intersect($this->getRoles(),$roles);
-    
+    $boolean_user = in_array($user, $this->getUsers());
+    $boolean_role = array_intersect($this->getRoles(), $roles);
+
     return ($boolean_user || $boolean_role || $boolean_default);
   }
 
@@ -221,7 +224,7 @@ abstract class XacmlRule {
   /**
    * Get roles associated with this XACML rule.
    *
-   * @return
+   * @return Array
    *   Array containing the roles.
    */
   function getRoles() {
@@ -262,9 +265,9 @@ class XacmlManagementRule extends XacmlRule {
    * @param $xacml
    *   Reference to the parent XACML object.
    */
-  function  __construct($arg1, $xacml) {
+  function __construct($arg1, $xacml) {
     parent::__construct($arg1, $xacml);
-    if($arg1 == NULL){
+    if ($arg1 == NULL) {
       $this->rule = $this->initializeRule(MANAGEMENT_RULE, 'Deny');
       $this->rule['methods'] = array(
         'addDatastream',
@@ -322,9 +325,9 @@ class XacmlViewingRule extends XacmlRule {
    * @param $xacml
    *   Reference to the parent XACML object.
    */
-  function  __construct($arg1, $xacml) {
+  function __construct($arg1, $xacml) {
     parent::__construct($arg1, $xacml);
-    if($arg1 == NULL){
+    if ($arg1 == NULL) {
       $this->rule = $this->initializeRule(VIEWING_RULE, 'Deny');
       $this->rule['methods'] = array(
         'api-a',
@@ -340,15 +343,15 @@ class XacmlViewingRule extends XacmlRule {
    * be possible to have people that could manage an object but not view datastreams. An unexpected behavior.
    *
    * @return
-   *   $rule datastructure parsable by XacmlWriter.
+   *   rule datastructure parsable by XacmlWriter.
    */
   function getRuleArray() {
     $rule = parent::getRuleArray();
-    if($this->xacml->managementRule->isPopulated()) {
+    if ($this->xacml->managementRule->isPopulated()) {
       $rule['users'] = array_unique(array_merge($rule['users'], $this->xacml->managementRule->getUsers()));
       $rule['roles'] = array_unique(array_merge($rule['roles'], $this->xacml->managementRule->getRoles()));
     }
-    if($this->xacml->datastreamRule->isPopulated()) {
+    if ($this->xacml->datastreamRule->isPopulated()) {
       $rule['users'] = array_unique(array_merge($rule['users'], $this->xacml->datastreamRule->getUsers()));
       $rule['roles'] = array_unique(array_merge($rule['roles'], $this->xacml->datastreamRule->getRoles()));
     }
@@ -364,7 +367,7 @@ class XacmlViewingRule extends XacmlRule {
  * This is entirely managed by Xacml object so not much needs to be said about it.
  */
 class XacmlPermitEverythingRule extends XacmlRule {
-  function  __construct($xacml) {
+  function __construct($xacml) {
     parent::__construct(NULL, $xacml);
     $this->rule = $this->initializeRule(PERMIT_RULE, 'Permit');
   }
@@ -389,9 +392,9 @@ class XacmlDatastreamRule extends XacmlRule {
    * @param $xacml
    *   Reference to parent Xacml object.
    */
-  function  __construct($arg1, $xacml) {
+  function __construct($arg1, $xacml) {
     parent::__construct($arg1, $xacml);
-    if($arg1 == NULL){
+    if ($arg1 == NULL) {
       $this->rule = $this->initializeRule(DATASTREAM_RULE, 'Deny');
       $this->rule['methods'][] = 'getDatastreamDissemination';
     }
@@ -403,13 +406,13 @@ class XacmlDatastreamRule extends XacmlRule {
    * be possible to have people that could manage an object but not view datastreams. An unexpected behavior.
    *
    * @return
-   *   $rule datastructure parsable by XacmlWriter.
+   *   rule datastructure parsable by XacmlWriter.
    */
   function getRuleArray() {
     $rule = parent::getRuleArray();
     $rule['dsids'] = $this->getValues('dsids');
     $rule['mimes'] = $this->getValues('mimes');
-    if($this->xacml->managementRule->isPopulated()) {
+    if ($this->xacml->managementRule->isPopulated()) {
       $rule['users'] = array_unique(array_merge($rule['users'], $this->xacml->managementRule->getUsers()));
       $rule['roles'] = array_unique(array_merge($rule['roles'], $this->xacml->managementRule->getRoles()));
     }
@@ -504,18 +507,18 @@ class XacmlDatastreamRule extends XacmlRule {
    */
   function hasPermission($user, $roles, $mime, $dsid) {
     // we need to check the isPopulated function for this one because it is overridden
-    if(!$this->isPopulated()) {
+    if (!$this->isPopulated()) {
       return TRUE;
     }
-    if(!parent::hasPermission($user, $roles)){
-        $boolean_mime = $mime ? in_array($mime,$this->getMimetypes()) : FALSE;
-        $boolean_dsid = $dsid ? in_array($dsid,$this->getDsids()) : FALSE;
-        if($boolean_mime || $boolean_dsid) {
-          return FALSE;
-        }
-        else {
-          return TRUE;
-        }
+    if (!parent::hasPermission($user, $roles)) {
+      $boolean_mime = $mime ? in_array($mime, $this->getMimetypes()) : FALSE;
+      $boolean_dsid = $dsid ? in_array($dsid, $this->getDsids()) : FALSE;
+      if ($boolean_mime || $boolean_dsid) {
+        return FALSE;
+      }
+      else {
+        return TRUE;
+      }
     }
     return TRUE;
   }
@@ -583,6 +586,7 @@ class Xacml {
    * @param (optional) $xacml The XACML XML as a string. If this isn't passed
    *   the constructor will instead create a new XACML object that permits
    *   everything.
+   *
    * @throws XacmlException if the XML cannot be parsed
    */
   function __construct($xacml = NULL) {
@@ -592,12 +596,12 @@ class Xacml {
     $datastream_rule = NULL;
     $viewing_rule = NULL;
 
-    if($xacml != NULL) {
+    if ($xacml != NULL) {
       $this->xacml = XacmlParser::parse($xacml);
 
       // decide what is enabled
-      foreach($this->xacml['rules'] as $rule) {
-        if($rule['ruleid'] == MANAGEMENT_RULE)
+      foreach ($this->xacml['rules'] as $rule) {
+        if ($rule['ruleid'] == MANAGEMENT_RULE)
           $management_rule = $rule;
         elseif ($rule['ruleid'] == DATASTREAM_RULE)
           $datastream_rule = $rule;
@@ -611,7 +615,7 @@ class Xacml {
 
     $this->datastreamRule = new XacmlDatastreamRule($datastream_rule, $this);
     $this->managementRule = new XacmlManagementRule($management_rule, $this);
-    $this->viewingRule = new XacmlViewingRule($viewing_rule,$this);
+    $this->viewingRule = new XacmlViewingRule($viewing_rule, $this);
     $this->permitEverythingRule = new XacmlPermitEverythingRule($this);
   }
 
@@ -625,14 +629,14 @@ class Xacml {
    *   (Optional) Defaults to POLICY. A string contrining the DSID to parse.
    *
    * @throws XacmlException
-   * @return an initialized Xacml object.
-   *
+   * @return
+   *   an initialized Xacml object.
    */
   static public function constructFromPid($pid, $dsid = 'POLICY') {
     module_load_include('inc', 'fedora_repository', 'api/fedora_item');
     $item = new Fedora_Item($pid);
     $datastreams = $item->get_datastreams_list_as_array();
-    if(isset($datastreams[$dsid])) {
+    if (isset($datastreams[$dsid])) {
       $xacml = $item->get_datastream_dissemination($dsid);
     }
     else {
@@ -648,13 +652,13 @@ class Xacml {
   private function updateRulesArray() {
     $this->xacml['rules'] = array();
 
-    if($this->datastreamRule->isPopulated())
+    if ($this->datastreamRule->isPopulated())
       $this->xacml['rules'][] = $this->datastreamRule->getRuleArray();
-    
-    if($this->managementRule->isPopulated())
+
+    if ($this->managementRule->isPopulated())
       $this->xacml['rules'][] = $this->managementRule->getRuleArray();
-    
-    if($this->viewingRule->isPopulated())
+
+    if ($this->viewingRule->isPopulated())
       $this->xacml['rules'][] = $this->viewingRule->getRuleArray();
 
     $this->xacml['rules'][] = $this->permitEverythingRule->getRuleArray();
@@ -664,6 +668,7 @@ class Xacml {
    * Returns the DomDocument that is associated with this Xacml Rule.
    *
    * @return DomDocument
+   *   The DomDocument associated with this Xacml rule.
    */
   function getDomDocument() {
     module_load_include('inc', 'islandora_xacml_api', 'XacmlWriter');
@@ -674,14 +679,15 @@ class Xacml {
   /**
    * Returns a string containing the XML for this XACML policy.
    *
-   * @param boolean $prettyPrint
+   * @param boolean $pretty_print
    *   If set to TRUE the function will return a prettyprinted xacml policy.
    *
-   * @return string containing xacml xml
+   * @return String
+   *   string containing xacml xml
    */
-  function getXmlString($prettyPrint=TRUE) {
+  function getXmlString($pretty_print = TRUE) {
     module_load_include('inc', 'islandora_xacml_api', 'XacmlWriter');
     $this->updateRulesArray();
-    return XacmlWriter::toXML($this->xacml, $prettyPrint);
+    return XacmlWriter::toXML($this->xacml, $pretty_print);
   }
 }

--- a/api/XacmlConstants.inc
+++ b/api/XacmlConstants.inc
@@ -8,12 +8,12 @@
  * Helper class specifying some useful constants.
  */
 class XacmlConstants {
-  const xacml = "urn:oasis:names:tc:xacml:1.0:policy";
-  const mime = "urn:fedora:names:fedora:2.1:resource:datastream:mimeType";
-  const dsid = "urn:fedora:names:fedora:2.1:resource:datastream:id";
-  const onememeberof = "urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of";
-  const stringequal = "urn:oasis:names:tc:xacml:1.0:function:string-equal";
-  const loginid = "urn:fedora:names:fedora:2.1:subject:loginId";
-  const xsi = 'http://www.w3.org/2001/XMLSchema-instance';
-  const xmlns = 'http://www.w3.org/2000/xmlns/';
+  const XACML = "urn:oasis:names:tc:xacml:1.0:policy";
+  const MIME = "urn:fedora:names:fedora:2.1:resource:datastream:mimeType";
+  const DSID = "urn:fedora:names:fedora:2.1:resource:datastream:id";
+  const ONEMEMBEROF = "urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of";
+  const STRINGEQUAL = "urn:oasis:names:tc:xacml:1.0:function:string-equal";
+  const LOGINID = "urn:fedora:names:fedora:2.1:subject:loginId";
+  const XSI = 'http://www.w3.org/2001/XMLSchema-instance';
+  const XMLNS = 'http://www.w3.org/2000/xmlns/';
 }

--- a/api/XacmlException.inc
+++ b/api/XacmlException.inc
@@ -2,7 +2,6 @@
 
 /**
  * @file
- *
  * This file defines the exceptions used in Islandora XACML editor.
  */
 
@@ -11,4 +10,5 @@
  * It currently doesn't override anything from the base exception class and is just here
  * as a placeholder.
  */
-class XacmlException extends Exception { }
+class XacmlException extends Exception {
+}

--- a/api/XacmlParser.inc
+++ b/api/XacmlParser.inc
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * @file
  * Contains the XacmlParser class.
  */
 
-include_once('XacmlConstants.inc');
-include_once('XacmlException.inc');
+include_once 'XacmlConstants.inc';
+include_once 'XacmlException.inc';
 
 /**
  * This static class takes an XACML XML file and parses it into the datastructures used by the XACML class.
@@ -25,32 +26,31 @@ class XacmlParser {
    * @return array()
    *   Array containing the XACML represented as datastructures.
    */
-  public static function parse ($xacml_string) {
+  public static function parse($xacml_string) {
     $xacml = array();
     $xacml['rules'] = array();
 
     // do some funky workaround stuff in order to get loadXML to throw an exception
     // instead of outputting a warning then failing in an ugly way later on
 
-
     $dom = new DomDocument();
-    $dom->preserveWhiteSpace = False;
+    $dom->preserveWhiteSpace = FALSE;
 
     // Throw exception if DomDocument gave us a Parse error
-    if($dom->loadXML($xacml_string) == FALSE) {
+    if ($dom->loadXML($xacml_string) == FALSE) {
       throw new XacmlException('Error Parsing XML.');
     }
 
     // Do basic sanity check that root element is <Policy>
-    if($dom->documentElement->tagName != 'Policy')
+    if ($dom->documentElement->tagName != 'Policy')
       throw new XacmlException('Root tag is not Policy.');
 
-    //see if the policy was written by islandora, othewise throw an exception
-    if(!$dom->documentElement->hasAttribute('PolicyId') || $dom->documentElement->getAttribute("PolicyId") != 'islandora-xacml-editor-v1')
+    // see if the policy was written by islandora, othewise throw an exception
+    if (!$dom->documentElement->hasAttribute('PolicyId') || $dom->documentElement->getAttribute("PolicyId") != 'islandora-xacml-editor-v1')
       throw new XacmlException('XACML file was not written by XACML Editor.');
-    
+
     $xpath = new DomXpath($dom);
-    $xpath->registerNamespace('xacml',XacmlConstants::xacml);
+    $xpath->registerNamespace('xacml', XacmlConstants::XACML);
     XacmlParser::parseXacml($xacml, $dom, $xpath);
 
     return $xacml;
@@ -65,17 +65,18 @@ class XacmlParser {
    *   The DOMElement for the <Rule> tag being parsed.
    */
   protected static function findDsidMime(&$rule, $element) {
-    $resources = $element->getElementsByTagNameNS(XacmlConstants::xacml, "ResourceMatch");
+    $resources = $element->getElementsByTagNameNS(XacmlConstants::XACML, "ResourceMatch");
 
-    foreach($resources as $resource) {
+    foreach ($resources as $resource) {
       $value = $resource->childNodes->item(0)->nodeValue;
       $type = $resource->childNodes->item(1)->getAttribute("AttributeId");
 
-      switch($type) {
-        case XacmlConstants::mime:
+      switch ($type) {
+        case XacmlConstants::MIME:
           $rule['mimes'][] = $value;
           break;
-        case XacmlConstants::dsid:
+
+        case XacmlConstants::DSID:
           $rule['dsids'][] = $value;
           break;
       }
@@ -88,24 +89,24 @@ class XacmlParser {
    * @param $rule
    *   The rule datastructure to add the ['methods'] array to.
    * @param $element
-   *   The DOMElement for rhte <Rule> tag being parsed.
+   *   The DOMElement for the <Rule> tag being parsed.
    */
   protected static function findMethods(&$rule, $element) {
-    $actions = $element->getElementsByTagNameNS(XacmlConstants::xacml, "Actions")->item(0);
-    $values = $actions->getElementsByTagNameNS(XacmlConstants::xacml, 'AttributeValue');
+    $actions = $element->getElementsByTagNameNS(XacmlConstants::XACML, "Actions")->item(0);
+    $values = $actions->getElementsByTagNameNS(XacmlConstants::XACML, 'AttributeValue');
 
-    foreach($values as $value) {
+    foreach ($values as $value) {
       $method = $value->nodeValue;
 
-      if(preg_match('/api-a/', $method) || preg_match('/api-m/', $method)) {
-        $rule['methods'][] = substr($method,35);
+      if (preg_match('/api-a/', $method) || preg_match('/api-m/', $method)) {
+        $rule['methods'][] = drupal_substr($method, 35);
       }
       else {
         // methods are returned as they are represented in XACML
         // for example: urn:fedora:names:fedora:2.1:action:id-getDatastreamDissemination
         // here we split off the first 38 characters, which for this example would
         // give us: getDatastreamDissemination
-        $rule['methods'][] = substr($method,38);
+        $rule['methods'][] = drupal_substr($method, 38);
       }
     }
   }
@@ -121,13 +122,13 @@ class XacmlParser {
    *   An DOMXPath class instantiated for this DOMDocument.
    */
   protected static function findRoles(&$rule, $element, $xpath) {
-    $role_designator = $xpath->query('.//xacml:Apply[@FunctionId="' . XacmlConstants::onememeberof .
-      '"]/xacml:SubjectAttributeDesignator[@AttributeId="fedoraRole"]',$element);
-    
-    if($role_designator->length != 0) {
-      $role_attrib = $xpath->query('../xacml:Apply/xacml:AttributeValue',$role_designator->item(0));
+    $role_designator = $xpath->query('.//xacml:Apply[@FunctionId="' . XacmlConstants::ONEMEMBEROF .
+      '"]/xacml:SubjectAttributeDesignator[@AttributeId="fedoraRole"]', $element);
 
-      foreach($role_attrib as $role) {
+    if ($role_designator->length != 0) {
+      $role_attrib = $xpath->query('../xacml:Apply/xacml:AttributeValue', $role_designator->item(0));
+
+      foreach ($role_attrib as $role) {
         $rule['roles'][] = $role->nodeValue;
       }
     }
@@ -144,13 +145,13 @@ class XacmlParser {
    *   An DOMXPath class instantiated for this DOMDocument.
    */
   protected static function findUsers(&$rule, $element, $xpath) {
-    $user_designator = $xpath->query('.//xacml:Apply[@FunctionId="' . XacmlConstants::onememeberof .
-      '"]/xacml:SubjectAttributeDesignator[@AttributeId="' . XacmlConstants::loginid . '"]',$element);
+    $user_designator = $xpath->query('.//xacml:Apply[@FunctionId="' . XacmlConstants::ONEMEMBEROF .
+      '"]/xacml:SubjectAttributeDesignator[@AttributeId="' . XacmlConstants::LOGINID . '"]', $element);
 
-    if($user_designator->length != 0) {
-      $user_attrib = $xpath->query('../xacml:Apply/xacml:AttributeValue',$user_designator->item(0));
+    if ($user_designator->length != 0) {
+      $user_attrib = $xpath->query('../xacml:Apply/xacml:AttributeValue', $user_designator->item(0));
 
-      foreach($user_attrib as $user) {
+      foreach ($user_attrib as $user) {
         $rule['users'][] = $user->nodeValue;
       }
     }
@@ -159,20 +160,20 @@ class XacmlParser {
   /**
    * Parses the passed in Xacml returning the $xacml array.
    *
-   * @param $rules
-   *   The rules array to be populated by this function.
+   * @param $xacml
+   *   The xacml rules array to be populated by this function.
    * @param $dom
    *   The DOMDocument containing the XACML.
    * @param $xpath
    *   An instantianted DOMXPath class for the above DOMDomcument.
    */
-  protected static function parseXacml(&$xacml, $dom, $xpath){
+  protected static function parseXacml(&$xacml, $dom, $xpath) {
     $xacml['PolicyId'] = $dom->documentElement->getAttribute("PolicyId");
     //$xacml['EditorVersion'] = $dom->documentElement->getAttribute("islandora_xacml");
     $xacml['RuleCombiningAlgId'] = $dom->documentElement->getAttribute("RuleCombiningAlgId");
 
-    # get each rule element
-    foreach($dom->getElementsByTagNameNS(XacmlConstants::xacml,"Rule") as $rule_element) {
+    // get each rule element
+    foreach ($dom->getElementsByTagNameNS(XacmlConstants::XACML, "Rule") as $rule_element) {
       $rule = array();
 
       $rule['effect'] = $rule_element->getAttribute("Effect");
@@ -183,7 +184,7 @@ class XacmlParser {
       $rule['users'] = array();
       $rule['roles'] = array();
 
-      if($rule['effect'] == 'Deny') {
+      if ($rule['effect'] == 'Deny') {
         XacmlParser::findDsidMime($rule, $rule_element);
         XacmlParser::findMethods($rule, $rule_element);
         XacmlParser::findRoles($rule, $rule_element, $xpath);

--- a/api/XacmlWriter.inc
+++ b/api/XacmlWriter.inc
@@ -3,13 +3,12 @@
 /**
  * @file
  * This file has functions for writing the XACML class datastructures out to XML.
- *
  */
 
-include_once('XacmlConstants.inc');
+include_once 'XacmlConstants.inc';
 
 /**
- * Class for writing XACML editor datasctructures out to XML.
+ * Class for writing XACML editor datastructures out to XML.
  */
 class XacmlWriter {
 
@@ -32,22 +31,22 @@ class XacmlWriter {
 
     return $dom;
   }
-  
+
   /**
    * Function takes a $xacml datastructure as input and returns
    * an string containing the XACML xml.
    *
    * @param $xacml
    *   $xacml datastructure
-   * @param $prettyprint
+   * @param $pretty_print
    *   Boolean. Determines if the output XML is formatted. Default: FALSE.
    *
    * @return
    *   String containing the XACML as XML.
    */
-  public static function toXML($xacml, $prettyprint=FALSE) {
+  public static function toXML($xacml, $pretty_print = FALSE) {
     $dom = XacmlWriter::toDom($xacml);
-    $dom->formatOutput = $prettyprint;
+    $dom->formatOutput = $pretty_print;
 
     return $dom->saveXML();
   }
@@ -56,13 +55,13 @@ class XacmlWriter {
    * Creates the root tag for the base XACML document.
    */
   private static function createRootElement(&$dom, $xacml) {
-    $root = $dom->createElementNS(XacmlConstants::xacml, 'Policy');
+    $root = $dom->createElementNS(XacmlConstants::XACML, 'Policy');
 
     //$root->setAttribute('islandora_xacml', '1.0');
-    $root->setAttribute('PolicyId','islandora-xacml-editor-v1');
-    $root->setAttribute('RuleCombiningAlgId',$xacml['RuleCombiningAlgId']);
-    $root->setAttributeNS(XacmlConstants::xmlns, 'xmlns', XacmlConstants::xacml);
-    $root->setAttributeNS(XacmlConstants::xmlns, 'xmlns:xsi', XacmlConstants::xsi);
+    $root->setAttribute('PolicyId', 'islandora-xacml-editor-v1');
+    $root->setAttribute('RuleCombiningAlgId', $xacml['RuleCombiningAlgId']);
+    $root->setAttributeNS(XacmlConstants::XMLNS, 'xmlns', XacmlConstants::XACML);
+    $root->setAttributeNS(XacmlConstants::XMLNS, 'xmlns:xsi', XacmlConstants::XSI);
 
     $dom->appendChild($root);
   }
@@ -87,18 +86,18 @@ class XacmlWriter {
    * @endcode
    */
   private static function createTarget(&$dom, $xacml) {
-    $target = $dom->createElementNS(XacmlConstants::xacml,'Target');
+    $target = $dom->createElementNS(XacmlConstants::XACML, 'Target');
 
-    $subject = $dom->createElementNS(XacmlConstants::xacml, 'Subjects');
-    $subject->appendChild($dom->createElementNS(XacmlConstants::xacml,'AnySubject'));
+    $subject = $dom->createElementNS(XacmlConstants::XACML, 'Subjects');
+    $subject->appendChild($dom->createElementNS(XacmlConstants::XACML, 'AnySubject'));
     $target->appendChild($subject);
 
-    $resource = $dom->createElementNS(XacmlConstants::xacml, 'Resources');
-    $resource->appendChild($dom->createElementNS(XacmlConstants::xacml,'AnyResource'));
+    $resource = $dom->createElementNS(XacmlConstants::XACML, 'Resources');
+    $resource->appendChild($dom->createElementNS(XacmlConstants::XACML, 'AnyResource'));
     $target->appendChild($resource);
 
-    $action = $dom->createElementNS(XacmlConstants::xacml, 'Actions');
-    $action->appendChild($dom->createElementNS(XacmlConstants::xacml,'AnyAction'));
+    $action = $dom->createElementNS(XacmlConstants::XACML, 'Actions');
+    $action->appendChild($dom->createElementNS(XacmlConstants::XACML, 'AnyAction'));
     $target->appendChild($action);
 
     $dom->documentElement->appendChild($target);
@@ -108,13 +107,13 @@ class XacmlWriter {
    * Create all of the <Rule> tags.
    */
   private static function createRules(&$dom, $xacml) {
-    foreach($xacml['rules'] as $rule) {
+    foreach ($xacml['rules'] as $rule) {
       XacmlWriter::createRule($dom, $rule);
     }
   }
 
   private static function createRule(&$dom, $rule) {
-    $root = $dom->createElementNS(XacmlConstants::xacml, "Rule");
+    $root = $dom->createElementNS(XacmlConstants::XACML, "Rule");
     $root->setAttribute('RuleId', $rule['ruleid']);
     $root->setAttribute('Effect', $rule['effect']);
 
@@ -125,7 +124,7 @@ class XacmlWriter {
   }
 
   private static function createRuleTarget(&$dom, &$root, $rule) {
-    $target = $dom->createElementNS(XacmlConstants::xacml,"Target");
+    $target = $dom->createElementNS(XacmlConstants::XACML, "Target");
 
     XacmlWriter::createRuleTargetSubjects($dom, $target, $rule);
     XacmlWriter::createRuleTargetResources($dom, $target, $rule);
@@ -135,32 +134,32 @@ class XacmlWriter {
   }
 
   private static function createRuleTargetSubjects(&$dom, &$target, $rule) {
-    $subjects = $dom->createElementNS(XacmlConstants::xacml, "Subjects");
-    $subjects->appendChild($dom->createElementNS(XacmlConstants::xacml,"AnySubject"));
+    $subjects = $dom->createElementNS(XacmlConstants::XACML, "Subjects");
+    $subjects->appendChild($dom->createElementNS(XacmlConstants::XACML, "AnySubject"));
     $target->appendChild($subjects);
   }
 
   private static function createRuleTargetActions(&$dom, &$target, $rule) {
-    $actions = $dom->createElementNS(XacmlConstants::xacml, "Actions");
-    if(!empty($rule['methods'])) {
-      foreach($rule['methods'] as $method) {
+    $actions = $dom->createElementNS(XacmlConstants::XACML, "Actions");
+    if (!empty($rule['methods'])) {
+      foreach ($rule['methods'] as $method) {
         XacmlWriter::createRuleTargetAction($dom, $actions, $method);
       }
     }
     else {
-      $actions->appendChild($dom->createElementNS(XacmlConstants::xacml,"AnyAction"));
+      $actions->appendChild($dom->createElementNS(XacmlConstants::XACML, "AnyAction"));
     }
 
     $target->appendChild($actions);
   }
 
   private static function createRuleTargetAction(&$dom, &$actions, $method) {
-    $action = $dom->createElementNS(XacmlConstants::xacml,'Action');
-    $actionMatch = $dom->createElementNS(XacmlConstants::xacml, 'ActionMatch');
-    $actionMatch->setAttribute('MatchId',XacmlConstants::stringequal);
-    $action->appendChild($actionMatch);
+    $action = $dom->createElementNS(XacmlConstants::XACML, 'Action');
+    $action_match = $dom->createElementNS(XacmlConstants::XACML, 'ActionMatch');
+    $action_match->setAttribute('MatchId', XacmlConstants::STRINGEQUAL);
+    $action->appendChild($action_match);
 
-    if($method == 'api-a' || $method == 'api-m') {
+    if ($method == 'api-a' || $method == 'api-m') {
       $attributevalue = "urn:fedora:names:fedora:2.1:action:$method";
       $attributeid = 'urn:fedora:names:fedora:2.1:action:api';
     }
@@ -169,27 +168,27 @@ class XacmlWriter {
       $attributeid = "urn:fedora:names:fedora:2.1:action:id";
     }
 
-    $attributeValue = $dom->createElementNS(XacmlConstants::xacml, "AttributeValue", $attributevalue);
-    $attributeValue->setAttribute("DataType","http://www.w3.org/2001/XMLSchema#string");
-    $actionAttributeDesignator = $dom->createElementNS(XacmlConstants::xacml, "ActionAttributeDesignator");
-    $actionAttributeDesignator->setAttribute("AttributeId", $attributeid);
-    $actionAttributeDesignator->setAttribute("DataType","http://www.w3.org/2001/XMLSchema#string");
-    $actionMatch->appendChild($attributeValue);
-    $actionMatch->appendChild($actionAttributeDesignator);
+    $attribute_value = $dom->createElementNS(XacmlConstants::XACML, "AttributeValue", $attributevalue);
+    $attribute_value->setAttribute("DataType", "http://www.w3.org/2001/XMLSchema#string");
+    $action_attribute_designator = $dom->createElementNS(XacmlConstants::XACML, "ActionAttributeDesignator");
+    $action_attribute_designator->setAttribute("AttributeId", $attributeid);
+    $action_attribute_designator->setAttribute("DataType", "http://www.w3.org/2001/XMLSchema#string");
+    $action_match->appendChild($attribute_value);
+    $action_match->appendChild($action_attribute_designator);
     $actions->appendChild($action);
   }
 
   private static function createRuleTargetResources(&$dom, &$target, $rule) {
-    $resources = $dom->createElementNS(XacmlConstants::xacml, "Resources");
+    $resources = $dom->createElementNS(XacmlConstants::XACML, "Resources");
 
-    if(empty($rule['mimes']) && empty($rule['dsids'])){
-      $resources->appendChild($dom->createElementNS(XacmlConstants::xacml,"AnyResource"));
+    if (empty($rule['mimes']) && empty($rule['dsids'])) {
+      $resources->appendChild($dom->createElementNS(XacmlConstants::XACML, "AnyResource"));
     }
     else {
-      foreach($rule['mimes'] as $mime) {
+      foreach ($rule['mimes'] as $mime) {
         XacmlWriter::createRuleTargetResource($dom, $resources, $mime, 'mime');
       }
-      foreach($rule['dsids'] as $dsid) {
+      foreach ($rule['dsids'] as $dsid) {
         XacmlWriter::createRuleTargetResource($dom, $resources, $dsid, 'dsid');
       }
     }
@@ -198,48 +197,50 @@ class XacmlWriter {
   }
 
   private static function createRuleTargetResource(&$dom, &$resources, $name, $type) {
-    $resource = $dom->createElementNS(XacmlConstants::xacml, 'Resource');
-    $resourceMatch = $dom->createElementNS(XacmlConstants::xacml, 'ResourceMatch');
-    $resourceMatch->setAttribute('MatchId',XacmlConstants::stringequal);
-    $resource->appendChild($resourceMatch);
+    $resource = $dom->createElementNS(XacmlConstants::XACML, 'Resource');
+    $resource_match = $dom->createElementNS(XacmlConstants::XACML, 'ResourceMatch');
+    $resource_match->setAttribute('MatchId', XacmlConstants::STRINGEQUAL);
+    $resource->appendChild($resource_match);
 
-    $AttributeValue = $dom->createElementNS(XacmlConstants::xacml, 'AttributeValue', $name);
-    $AttributeValue->setAttribute('DataType',"http://www.w3.org/2001/XMLSchema#string");
+    $attribute_value = $dom->createElementNS(XacmlConstants::XACML, 'AttributeValue', $name);
+    $attribute_value->setAttribute('DataType', "http://www.w3.org/2001/XMLSchema#string");
 
-    $ResourceAttributeDesignator = $dom->createElementNS(XacmlConstants::xacml, 'ResourceAttributeDesignator');
-    $ResourceAttributeDesignator->setAttribute("DataType","http://www.w3.org/2001/XMLSchema#string");
+    $resource_attribute_designator = $dom->createElementNS(XacmlConstants::XACML, 'ResourceAttributeDesignator');
+    $resource_attribute_designator->setAttribute("DataType", "http://www.w3.org/2001/XMLSchema#string");
 
-    switch ($type){
+    switch ($type) {
       case 'mime':
-        $ResourceAttributeDesignator->setAttribute("AttributeId","urn:fedora:names:fedora:2.1:resource:datastream:mimeType");
+        $resource_attribute_designator->setAttribute("AttributeId", "urn:fedora:names:fedora:2.1:resource:datastream:mimeType");
         break;
+
       case 'dsid':
-        $ResourceAttributeDesignator->setAttribute("AttributeId","urn:fedora:names:fedora:2.1:resource:datastream:id");
+        $resource_attribute_designator->setAttribute("AttributeId", "urn:fedora:names:fedora:2.1:resource:datastream:id");
         break;
+
       default:
-        return False;
+        return FALSE;
     }
 
-    $resourceMatch->appendChild($AttributeValue);
-    $resourceMatch->appendChild($ResourceAttributeDesignator);
+    $resource_match->appendChild($attribute_value);
+    $resource_match->appendChild($resource_attribute_designator);
 
     $resources->appendChild($resource);
   }
 
   private static function createRuleCondition(&$dom, &$target, $rule) {
-    $condition = $dom->createElementNS(XacmlConstants::xacml,"Condition");
+    $condition = $dom->createElementNS(XacmlConstants::XACML, "Condition");
     $condition->setAttribute("FunctionId", "urn:oasis:names:tc:xacml:1.0:function:not");
 
-    if(!empty($rule['users'])) {
-      $users = XacmlWriter::createRuleConditionApply($dom, $rule['users'],'user');
+    if (!empty($rule['users'])) {
+      $users = XacmlWriter::createRuleConditionApply($dom, $rule['users'], 'user');
     }
-    if(!empty($rule['roles'])) {
-      $roles = XacmlWriter::createRuleConditionApply($dom, $rule['roles'],'role');
+    if (!empty($rule['roles'])) {
+      $roles = XacmlWriter::createRuleConditionApply($dom, $rule['roles'], 'role');
     }
 
-    if(isset($users) && isset($roles)) {
-      $apply = $dom->createElementNS(XacmlConstants::xacml, "Apply");
-      $apply->setAttribute("FunctionId","urn:oasis:names:tc:xacml:1.0:function:or");
+    if (isset($users) && isset($roles)) {
+      $apply = $dom->createElementNS(XacmlConstants::XACML, "Apply");
+      $apply->setAttribute("FunctionId", "urn:oasis:names:tc:xacml:1.0:function:or");
       $condition->appendChild($apply);
       $apply->appendChild($users);
       $apply->appendChild($roles);
@@ -258,34 +259,36 @@ class XacmlWriter {
   }
 
   private static function createRuleConditionApply(&$dom, $attributes, $type) {
-    $apply = $dom->createElementNS(XacmlConstants::xacml,'Apply');
-    $apply->setAttribute("FunctionId","urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of");
+    $apply = $dom->createElementNS(XacmlConstants::XACML, 'Apply');
+    $apply->setAttribute("FunctionId", "urn:oasis:names:tc:xacml:1.0:function:string-at-least-one-member-of");
 
-    $subjectAttribureDesignator = $dom->createElementNS(XacmlConstants::xacml, 'SubjectAttributeDesignator');
-    $subjectAttribureDesignator->setAttribute("DataType","http://www.w3.org/2001/XMLSchema#string");
-    $subjectAttribureDesignator->setAttribute("MustBePresent","false");
+    $subject_attribute_designator = $dom->createElementNS(XacmlConstants::XACML, 'SubjectAttributeDesignator');
+    $subject_attribute_designator->setAttribute("DataType", "http://www.w3.org/2001/XMLSchema#string");
+    $subject_attribute_designator->setAttribute("MustBePresent", "false");
 
-    switch($type) {
+    switch ($type) {
       case 'role':
-        $subjectAttribureDesignator->setAttribute('AttributeId',"fedoraRole");
+        $subject_attribute_designator->setAttribute('AttributeId', "fedoraRole");
         break;
+
       case 'user':
-        $subjectAttribureDesignator->setAttribute('AttributeId',"urn:fedora:names:fedora:2.1:subject:loginId");
+        $subject_attribute_designator->setAttribute('AttributeId', "urn:fedora:names:fedora:2.1:subject:loginId");
         break;
+
       default:
         return NULL;
     }
 
-    $apply->appendChild($subjectAttribureDesignator);
+    $apply->appendChild($subject_attribute_designator);
 
-    $stringBag = $dom->createElementNS(XacmlConstants::xacml,"Apply");
-    $stringBag->setAttribute("FunctionId","urn:oasis:names:tc:xacml:1.0:function:string-bag");
-    $apply->appendChild($stringBag);
+    $string_bag = $dom->createElementNS(XacmlConstants::XACML, "Apply");
+    $string_bag->setAttribute("FunctionId", "urn:oasis:names:tc:xacml:1.0:function:string-bag");
+    $apply->appendChild($string_bag);
 
-    foreach($attributes as $attribute) {
-      $attrib = $dom->createElementNS(XacmlConstants::xacml, "AttributeValue", $attribute);
-      $attrib->setAttribute("DataType","http://www.w3.org/2001/XMLSchema#string");
-      $stringBag->appendChild($attrib);
+    foreach ($attributes as $attribute) {
+      $attrib = $dom->createElementNS(XacmlConstants::XACML, "AttributeValue", $attribute);
+      $attrib->setAttribute("DataType", "http://www.w3.org/2001/XMLSchema#string");
+      $string_bag->appendChild($attrib);
     }
 
     return $apply;

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -2,7 +2,6 @@
 
 /**
  * @file
- *
  * The main module file for the Islanora XACML Editor
  */
 
@@ -14,7 +13,7 @@ function islandora_xacml_editor_perm() {
 }
 
 /**
- * Implementaion of hook_menu()
+ * Implementaion of hook_menu().
  * @todo Decide on the correct menu paths.
  */
 function islandora_xacml_editor_menu() {
@@ -25,7 +24,7 @@ function islandora_xacml_editor_menu() {
     'description' => 'Edit XACML policies for a particular object.',
     'type' => MENU_CALLBACK,
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('islandora_xacml_editor_page',1,2),
+    'page arguments' => array('islandora_xacml_editor_page', 1, 2),
     'access arguments' => array('Edit XACML Policies'),
   );
 
@@ -65,7 +64,7 @@ function islandora_xacml_editor_islandora_tabs($content_models, $pid) {
       $tabs['xacml_policy'] = array(
         '#type' => 'tabpage',
         '#title' => $title,
-        '#content' => drupal_get_form('islandora_xacml_editor_page',$pid,$dsid),
+        '#content' => drupal_get_form('islandora_xacml_editor_page', $pid, $dsid),
       );
     }
   }
@@ -81,11 +80,11 @@ function islandora_xacml_editor_settings() {
     '#type' => 'checkbox',
     '#title' => t('Show Policy Tabs'),
     '#description' => t("Show a tab for the XACML Policy Editor on each Fedora item's page. For normal items, this policy will only apply to the item itself; in the case of collection items (having the content model &lt;islandora:collectionCModel&gt;), this will be a child policy."),
-    '#default_value' => variable_get('islandora_xacml_editor_show_tabs',1),
+    '#default_value' => variable_get('islandora_xacml_editor_show_tabs', 1),
   );
   $form['islandora_xacml_editor_save_relationships'] = array(
-	  '#type' => 'checkbox',
-	  '#title' => t('Save policy details in RELS-EXT'),
+    '#type' => 'checkbox',
+    '#title' => t('Save policy details in RELS-EXT'),
     '#description' => t("Add <islandora:isViewableByUser> and <islandora:isViewableByRole> relationships to objects' RELS-EXT datastreams when XACML viewing restrictions are in place."),
     '#default_value' => variable_get('islandora_xacml_editor_save_relationships', FALSE),
   );
@@ -104,7 +103,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
 
   // when we call in from top level collections in JS get get the
   // pid being undefined
-  if($object_pid == 'undefined' || !$object_pid) {
+  if ($object_pid == 'undefined' || !$object_pid) {
     $object_pid = variable_get('fedora_repository_pid', 'islandora:top');
   }
 
@@ -112,19 +111,19 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   $form_state['storage']['object_pid'] = $object_pid;
   $form_state['storage']['xacml_dsid'] = $xacml_dsid;
 
-  if(!valid_pid($object_pid) || !valid_dsid($xacml_dsid)) {
+  if (!valid_pid($object_pid) || !valid_dsid($xacml_dsid)) {
     drupal_not_found();
     exit();
   }
 
   $object = new Fedora_Item($object_pid);
-  if(!$object->exists()) {
+  if (!$object->exists()) {
     drupal_not_found();
     exit();
   }
   $breadcrumbs = array();
-  $objectHelper = new ObjectHelper();
-  $objectHelper->getBreadcrumbs($object_pid, $breadcrumbs);
+  $object_helper = new ObjectHelper();
+  $object_helper->getBreadcrumbs($object_pid, $breadcrumbs);
   drupal_set_breadcrumb(array_reverse($breadcrumbs));
   $datastreams = $object->get_datastreams_list_as_array();
 
@@ -134,17 +133,17 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
 
   module_load_include('inc', 'fedora_repository', 'ContentModel');
 
-  if($xacml_dsid == 'CHILD_SECURITY') {
+  if ($xacml_dsid == 'CHILD_SECURITY') {
     module_load_include('inc', 'fedora_repository', 'CollectionPolicy');
 
     $collection = CollectionPolicy::loadFromCollection($object_pid);
-    if($collection) {
+    if ($collection) {
       $cms = $collection->getContentModels();
-      foreach($cms as $cm) {
+      foreach ($cms as $cm) {
         $contentmodel = ContentModel::loadFromModel($cm->pid);
-        if($contentmodel) {
+        if ($contentmodel) {
           $tmp = $contentmodel->getMimetypes();
-          foreach($tmp as $t) {
+          foreach ($tmp as $t) {
             $mime[$t] = $t;
           }
         }
@@ -153,15 +152,15 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   }
   else {
     $contentmodel = ContentModel::loadFromObject($object_pid);
-    if($contentmodel) {
+    if ($contentmodel) {
       $tmp = $contentmodel->getMimetypes();
-      foreach($tmp as $t) {
+      foreach ($tmp as $t) {
         $mime[$t] = $t;
       }
     }
   }
 
-  foreach($datastreams as $k => $ds) {
+  foreach ($datastreams as $k => $ds) {
     $mime[$ds['MIMEType']] = $ds['MIMEType'];
     $dsid[$k] = $k;
   }
@@ -169,9 +168,9 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   // get the user list
   $users = array();
   $result = db_query('SELECT u.uid, u.name FROM {users} u');
-  while($user = db_fetch_object($result)) {
+  while ($user = db_fetch_object($result)) {
     $user->uid == 0 ? $users['anonymous'] = 'anonymous' : $users[$user->name] = $user->name;
-    if($user->uid == 1) {
+    if ($user->uid == 1) {
       $admin_user = $user->name;
       $form_state['storage']['admin_user'] = $user->name;
     }
@@ -183,11 +182,11 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   // get role list
   $roles = array();
   $result = db_query('SELECT r.rid, r.name FROM {role} r');
-  while($role = db_fetch_object($result)) {
+  while ($role = db_fetch_object($result)) {
     $role->rid == 0 ? $roles['anonymous'] = 'anonymous' : $roles[$role->name] = $role->name;
   }
 
-  if(array_key_exists($xacml_dsid, $datastreams)) {
+  if (array_key_exists($xacml_dsid, $datastreams)) {
     module_load_include('inc', 'islandora_xacml_api', 'XacmlException');
 
     // here we populate the form
@@ -197,9 +196,11 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     try {
       $xacml = new Xacml($xml);
     }
-    catch(XacmlException $e) {
-      drupal_set_message($e->getMessage());
-      drupal_set_message("Xacml Parser failed to parse $object_pid/$xacml_dsid. It is likely this POLICY wasn't written by the islandora XACML editor, it will have to be modified by hand.");
+    catch (XacmlException $e) {
+      watchdog('islandora_xacml_editor', $e->getMessage(), array(), WATCHDOG_ERROR);
+      drupal_set_message(t("Xacml Parser failed to parse @object_pid/@xacml_dsid. It is likely this POLICY wasn't written by the islandora XACML editor, it will have to be modified by hand.",
+                          array("@object_pid" => $object_pid, "@xacml_dsid" => $xacml_dsid))
+                        );
       drupal_not_found();
       exit();
     }
@@ -325,7 +326,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#default_value' => $xacml->datastreamRule->isPopulated() ? $xacml->datastreamRule->getMimetypes() : NULL,
   );
 
- if($xacml_dsid == 'CHILD_SECURITY') {
+  if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options'] = array(
       '#type' => 'select',
       '#title' => t('What items would you like to apply this policy to?'),
@@ -353,16 +354,15 @@ function islandora_xacml_editor_page_validate(&$form, &$form_state) {
   $current_user = $form_state['storage']['current_user'];
 
   // management functions
-  if(!array_key_exists($admin_user,$form_state['values']['manage']['users']) ||
-      !array_key_exists($current_user,$form_state['values']['manage']['users']) )
-  {
-    if($admin_user == $current_user) {
-      form_set_error('manage][users',"Please make sure that $admin_user is selected in the manage
-        section to prevent locking yourself out of the object.",FALSE);
+  if (!array_key_exists($admin_user, $form_state['values']['manage']['users']) ||
+      !array_key_exists($current_user, $form_state['values']['manage']['users'])) {
+    if ($admin_user == $current_user) {
+      form_set_error('manage][users', "Please make sure that $admin_user is selected in the manage
+        section to prevent locking yourself out of the object.", FALSE);
     }
     else {
-      form_set_error('manage][users',"Please make sure that $admin_user and $current_user are selected in the manage
-        section to prevent locking yourself and the admin user out of the object.",FALSE);
+      form_set_error('manage][users', "Please make sure that $admin_user and $current_user are selected in the manage
+        section to prevent locking yourself and the admin user out of the object.", FALSE);
     }
   }
 }
@@ -378,7 +378,7 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
 
   // check datastreams and mime
   $values = $form_state['values']['dsidmime'];
-  if( $values['enabled'] ) {
+  if ($values['enabled']) {
     $xacml->datastreamRule->addMimetype($values['mime']);
     $xacml->datastreamRule->addDsid($values['dsid']);
     $xacml->datastreamRule->addUser($values['users']);
@@ -392,7 +392,7 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
 
   // check access
   $values = $form_state['values']['access'];
-  if( $values['enabled'] ) {
+  if ($values['enabled']) {
     $xacml->viewingRule->addUser($values['users']);
     $xacml->viewingRule->addRole($values['roles']);
   }
@@ -404,7 +404,7 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
   $object = new Fedora_Item($pid);
   $datastreams = $object->get_datastreams_list_as_array();
 
-  if(array_key_exists($dsid, $datastreams)) {
+  if (array_key_exists($dsid, $datastreams)) {
     $object->modify_datastream_by_value($xml, $dsid, 'Xacml Policy Stream', 'text/xml');
   }
   else {
@@ -422,24 +422,27 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
     $values = $form_state['values']['access'];
     // recompute the new values from the policy
     if (isset($values['users'])) {
-      foreach($values['users'] as $account) {
+      foreach ($values['users'] as $account) {
         $object->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
       }
     }
     if (isset($values['roles'])) {
-      foreach($values['roles'] as $role) {
+      foreach ($values['roles'] as $role) {
         $object->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
       }
     }
   }
 
-  if($dsid == 'CHILD_SECURITY' && $form_state['values']['update_options'] != 'newchildren') {
+  if ($dsid == 'CHILD_SECURITY' && $form_state['values']['update_options'] != 'newchildren') {
     $option = $form_state['values']['update_options'];
     $batch = array(
       'title' => t('Updating Policies'),
       'progress_message' => t('Please wait if many objects are being updated this could take a few minutes.'),
       'operations' => array(
-        array('islandora_xacml_editor_batch_function', array($xml, $pid, $option)),
+        array(
+          'islandora_xacml_editor_batch_function',
+          array($xml, $pid, $option)
+        ),
       ),
       'finished' => 'islandora_xacml_editor_batch_finished',
     );
@@ -473,7 +476,7 @@ function islandora_xacml_editor_batch_function($xml, $pid, $option, &$context) {
   $policy_update = new IslandoraUpdatePolicy($targetpid, $xml);
   $success = $policy_update->updatePolicy();
 
-  if($success) {
+  if ($success) {
     $context['results']['success'][] = $targetpid;
   }
   else {
@@ -495,7 +498,7 @@ function islandora_xacml_editor_batch_finished($success, $results, $operations) 
 
   if ($results['fail']) {
     foreach ($results['fail'] as $fail) {
-      drupal_set_message("Failed to update: $fail. You do not have permission to update this object.", 'error');
+      drupal_set_message(t("Failed to update: @failed_object. You do not have permission to update this object.", array('@failed_object' => $fail)), 'error');
     }
   }
 
@@ -509,37 +512,37 @@ function islandora_xacml_editor_batch_finished($success, $results, $operations) 
  * query will be modified to use xacml rules.
  */
 function islandora_xacml_editor_islandora_collection_query_alter(&$query, $pid) {
-    global $user;
-    $query = 'select $object $title $model $parent_model $created from <#ri>
-              where
-              ((
-              $object <fedora-model:label> $title
-              and $object <fedora-model:hasModel> $model
-              and $object <fedora-model:createdDate> $created
-              and $model <fedora-model:hasModel> $parent_model
-              and $object <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
-              and ( $object <fedora-rels-ext:isMemberOfCollection> <info:fedora/' . $pid . '>
-              or $object <fedora-rels-ext:isMemberOf> <info:fedora/' . $pid . '> )
-              minus $object <http://islandora.ca/ontology/relsext#isViewableByRole> $role
-              minus $object <http://islandora.ca/ontology/relsext#isViewableByUser> $user
-              ) or (
-              $object <fedora-model:label> $title
-              and $object <fedora-model:hasModel> $model
-              and $object <fedora-model:createdDate> $created
-              and $model <fedora-model:hasModel> $parent_model
-              and $object <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
-              and ( $object <fedora-rels-ext:isMemberOfCollection> <info:fedora/' . $pid . '>
-              or $object <fedora-rels-ext:isMemberOf> <info:fedora/' . $pid . '> )
-              and (';
-    foreach ($user->roles as $role) {
-      $query .= '$object <http://islandora.ca/ontology/relsext#isViewableByRole> '."'$role' or ";
-    }
-    $query .= '$object <http://islandora.ca/ontology/relsext#isViewableByUser> '."'$user->name'".')';
-    $query .= '))
-              minus $model <mulgara:is> <info:fedora/fedora-system:FedoraObject-3.0>
-              minus $parent_model <mulgara:is> <info:fedora/fedora-system:FedoraObject-3.0>
-              order by $title';
-    return $query;
+  global $user;
+  $query = 'select $object $title $model $parent_model $created from <#ri>
+            where
+            ((
+            $object <fedora-model:label> $title
+            and $object <fedora-model:hasModel> $model
+            and $object <fedora-model:createdDate> $created
+            and $model <fedora-model:hasModel> $parent_model
+            and $object <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
+            and ( $object <fedora-rels-ext:isMemberOfCollection> <info:fedora/' . $pid . '>
+            or $object <fedora-rels-ext:isMemberOf> <info:fedora/' . $pid . '> )
+            minus $object <http://islandora.ca/ontology/relsext#isViewableByRole> $role
+            minus $object <http://islandora.ca/ontology/relsext#isViewableByUser> $user
+            ) or (
+            $object <fedora-model:label> $title
+            and $object <fedora-model:hasModel> $model
+            and $object <fedora-model:createdDate> $created
+            and $model <fedora-model:hasModel> $parent_model
+            and $object <fedora-model:state> <info:fedora/fedora-system:def/model#Active>
+            and ( $object <fedora-rels-ext:isMemberOfCollection> <info:fedora/' . $pid . '>
+            or $object <fedora-rels-ext:isMemberOf> <info:fedora/' . $pid . '> )
+            and (';
+  foreach ($user->roles as $role) {
+    $query .= '$object <http://islandora.ca/ontology/relsext#isViewableByRole> ' . "'$role' or ";
+  }
+  $query .= '$object <http://islandora.ca/ontology/relsext#isViewableByUser> ' . "'$user->name'" . ')';
+  $query .= '))
+            minus $model <mulgara:is> <info:fedora/fedora-system:FedoraObject-3.0>
+            minus $parent_model <mulgara:is> <info:fedora/fedora-system:FedoraObject-3.0>
+            order by $title';
+  return $query;
 }
 
 class IslandoraUpdatePolicy {
@@ -562,11 +565,11 @@ class IslandoraUpdatePolicy {
     $query_results = IslandoraXacmlEditorQuery::query($query);
     $results = new SimpleXMLElement($query_results);
     $collection = FALSE;
-    foreach($results->results->result as $result) {
-      $pid = (string)$result->parent_model['uri'];
-      $pid = explode('/',$pid);
+    foreach ($results->results->result as $result) {
+      $pid = (string) $result->parent_model['uri'];
+      $pid = explode('/', $pid);
       $pid = $pid[1];
-      if($pid == 'islandora:collectionCModel') {
+      if ($pid == 'islandora:collectionCModel') {
         $collection = TRUE;
       }
     }
@@ -576,16 +579,17 @@ class IslandoraUpdatePolicy {
   function updatePolicy() {
     global $user;
     $success = FALSE;
-    if($this->object->exists()) {
+    if ($this->object->exists()) {
       $datastreams = $this->object->get_datastreams_list_as_array();
-      if(array_key_exists('POLICY', $datastreams)) {
+      if (array_key_exists('POLICY', $datastreams)) {
         try {
           $xacml = Xacml::constructFromPid($this->pid);
-          if($xacml->managementRule->hasPermission($user->name, $user->roles)) {
+          if ($xacml->managementRule->hasPermission($user->name, $user->roles)) {
             $success = $this->addOrUpdateAllPolicies($datastreams);
           }
         }
-        catch (XacmlException $e) {}
+        catch (XacmlException $e) {
+        }
       }
       else {
         $success = $this->addOrUpdateAllPolicies($datastreams);
@@ -596,14 +600,14 @@ class IslandoraUpdatePolicy {
 
   private function addOrUpdateAllPolicies($datastreams) {
     $ret = $this->addOrUpdatePolicy($datastreams, 'POLICY');
-    if($this->isCollection()) {
+    if ($this->isCollection()) {
       $ret &= $this->addOrUpdatePolicy($datastreams, 'CHILD_SECURITY');
     }
     return $ret;
   }
 
   private function addOrUpdatePolicy($datastreams, $dsid) {
-    if(array_key_exists($dsid, $datastreams)) {
+    if (array_key_exists($dsid, $datastreams)) {
       return $this->object->modify_datastream_by_value($this->xml, $dsid, 'Xacml Policy Stream', 'text/xml');
     }
     else {
@@ -634,16 +638,16 @@ class IslandoraXacmlEditorQuery {
   function getCount() {
     $query_results = IslandoraXacmlEditorQuery::query($this->getCountQuery());
     $results = new SimpleXMLElement($query_results);
-    return (int)$results->results->result[0]->k0;
+    return (int) $results->results->result[0]->k0;
   }
 
   function getPids() {
     $pids = array();
     $query_results = IslandoraXacmlEditorQuery::query($this->getQuery());
     $results = new SimpleXMLElement($query_results);
-    foreach($results->results->result as $result) {
-      $pid = (string)$result->object['uri'];
-      $parts = explode('/',$pid);
+    foreach ($results->results->result as $result) {
+      $pid = (string) $result->object['uri'];
+      $parts = explode('/', $pid);
       $pids[] = $parts[1];
     }
     return $pids;


### PR DESCRIPTION
mostly little things like improper spacing and a couple of commenting errors.  There are a few notes: the xacml constants (XamlConstants.inc) were all renamed to upper case (and the typo onememeberof was corrected).  The case has been corrected in this module and appears to have no effect elsewhere.

There are a couple of places in api/XacmlParser.inc where large blocks are shown as different - these are mostly attributed to the constant case change.

This is not a complete array of fixes, drupal code sniffer still reports many docstring errors to be fixed.
