### PR TITLE
6.x

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,13 @@
+---- Fedora configuration ----
+
+It may be desirable--and in fact necessary for some modules--to disable/remove
+one of the default XACML policies which denies any interactions with the
+POLICY datastream to users without the "administrator" role.
+
+---- Issues with autocomplete ----
+
 There are two known issues that exist within Drupal's autocomplete that can be fixed by patching Drupal.
 
 First issue is "."s appearing in the autocomplete field resulting in a 404 error (http://drupal.org/node/93854#comment-6164592).
-
 Second issue is when pressing the down arrow and focusing on another field "undefined" appears in the textfield (http://drupal.org/node/172755).
-
-
 

--- a/api/IslandoraXacml.inc
+++ b/api/IslandoraXacml.inc
@@ -27,7 +27,7 @@ class IslandoraXacml extends Xacml {
       $xacml = $item->get_datastream_dissemination($dsid);
     }
     
-    parent::_construct($xacml);
+    parent::__construct($xacml);
     $this->pid = $pid;
     $this->dsid = $dsid;
     $this->item = $item;
@@ -36,10 +36,45 @@ class IslandoraXacml extends Xacml {
   function writeBackToFedora() {
     $xml = $this->getXmlString();
     if (array_key_exists($this->dsid, $this->item->datastreams)) {
-      return $this->item->modify_datastream($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml');
+      $this->item->modify_datastream($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml');
     }
     else {
-      return $this->item->add_datastream_from_string($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml', 'X');
+      $this->item->add_datastream_from_string($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml', 'X');
+    }
+
+    $viewable_by_user = 'isViewableByUser';
+    $viewable_by_role = 'isViewableByRole';
+    // remove all old policy related rels-ext statements
+
+    if (variable_get('islandora_xacml_editor_save_relationships', TRUE)) {
+      $this->item->purge_relationships($viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+      $this->item->purge_relationships($viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+      foreach (array_keys($this->item->datastreams) as $dsid) {
+        $this->item->purge_dsid_relationships($dsid, $viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+        $this->item->purge_dsid_relationships($dsid, $viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+      }
+
+      if ($this->viewingRule->isPopulated()) {
+        // recompute the new values from the policy
+        foreach ($this->viewingRule->getValues('users') as $account) {
+          $this->item->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+        }
+        foreach ($this->viewingRule->getValues('roles') as $role) {
+          $this->item->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+        }
+      }
+
+      if ($this->datastreamRule->isPopulated()) {
+        foreach ($this->datastreamRule->getValues('dsid') as $dsid) {
+          // recompute the new values from the policy
+          foreach ($this->datastreamRule->getValues('users') as $account) {
+            $this->item->add_dsid_relationship($dsid, $viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+          }
+          foreach ($this->datastreamRule->getValues('roles') as $role) {
+            $this->item->add_dsid_relationship($dsid, $viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+          }
+        } 
+      }
     }
   }
 }

--- a/api/IslandoraXacml.inc
+++ b/api/IslandoraXacml.inc
@@ -56,21 +56,21 @@ class IslandoraXacml extends Xacml {
 
       if ($this->viewingRule->isPopulated()) {
         // recompute the new values from the policy
-        foreach ($this->viewingRule->getValues('users') as $account) {
+        foreach ($this->viewingRule->getUsers() as $account) {
           $this->item->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
         }
-        foreach ($this->viewingRule->getValues('roles') as $role) {
+        foreach ($this->viewingRule->getRoles() as $role) {
           $this->item->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
         }
       }
 
       if ($this->datastreamRule->isPopulated()) {
-        foreach ($this->datastreamRule->getValues('dsid') as $dsid) {
+        foreach ($this->datastreamRule->getDsids() as $dsid) {
           // recompute the new values from the policy
-          foreach ($this->datastreamRule->getValues('users') as $account) {
+          foreach ($this->datastreamRule->getUsers() as $account) {
             $this->item->add_dsid_relationship($dsid, $viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
           }
-          foreach ($this->datastreamRule->getValues('roles') as $role) {
+          foreach ($this->datastreamRule->getRoles() as $role) {
             $this->item->add_dsid_relationship($dsid, $viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
           }
         } 

--- a/api/IslandoraXacml.inc
+++ b/api/IslandoraXacml.inc
@@ -4,7 +4,7 @@ module_load_include('inc', 'islandora_xacml_api', 'Xacml');
 
 /**
  * Subclass Xacml to facilitate communication to Islandora/Fedora.
- * 
+ *
  * Need to have Drupal bootstrapped, due to use of module_load_includes
  */
 class IslandoraXacml extends Xacml {
@@ -17,22 +17,37 @@ class IslandoraXacml extends Xacml {
    * @var $dsid
    */
   protected $item, $pid, $dsid;
-  
-  function __construct($pid, $dsid = 'POLICY') {
+
+  /**
+   * Constructor.
+   *
+   * @param $pid
+   *   A string containing a Fedora PID, from which to attempt to load and
+   *   write back to.
+   * @param $dsid
+   *   A string containing a Fedora DSID, from which to attempt to load and
+   *   write back to.
+   * @param $xacml
+   *   A string containing XACML XML, or NULL to attempt to load from the given
+   *   PID and DSID.
+   */
+  function __construct($pid, $dsid = 'POLICY', $xacml = NULL) {
     module_load_include('inc', 'fedora_repository', 'api/fedora_item');
     $item = new Fedora_Item($pid);
-    
-    $xacml = NULL;
-    if (isset($item->datastreams[$dsid])) {
+
+    if ($xacml === NULL && isset($item->datastreams[$dsid])) {
       $xacml = $item->get_datastream_dissemination($dsid);
     }
-    
+
     parent::__construct($xacml);
     $this->pid = $pid;
     $this->dsid = $dsid;
     $this->item = $item;
   }
 
+  /**
+   * Writes our XACML stream to our PID/DSID pair...
+   */
   function writeBackToFedora() {
     $xml = $this->getXmlString();
     if (array_key_exists($this->dsid, $this->item->datastreams)) {
@@ -42,38 +57,48 @@ class IslandoraXacml extends Xacml {
       $this->item->add_datastream_from_string($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml', 'X');
     }
 
+
+
+    //Only add relationships on POLICY datastream, as only the POLICY is enforced.
+    if ($this->dsid == 'POLICY' && variable_get('islandora_xacml_editor_save_relationships', TRUE)) {
+      $this->writeRelations();
+    }
+    return TRUE;
+  }
+
+  protected function writeRelations() {
     $viewable_by_user = 'isViewableByUser';
     $viewable_by_role = 'isViewableByRole';
+
     // remove all old policy related rels-ext statements
+    $this->item->purge_relationships($viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+    $this->item->purge_relationships($viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+    foreach (array_keys($this->item->datastreams) as $dsid) {
+      //XXX:  These use the RELS-EXT URI...
+      $this->item->purge_dsid_relationships($dsid, $viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+      $this->item->purge_dsid_relationships($dsid, $viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+    }
 
-    if (variable_get('islandora_xacml_editor_save_relationships', TRUE)) {
-      $this->item->purge_relationships($viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-      $this->item->purge_relationships($viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-      foreach (array_keys($this->item->datastreams) as $dsid) {
-        $this->item->purge_dsid_relationships($dsid, $viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-        $this->item->purge_dsid_relationships($dsid, $viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+    if ($this->viewingRule->isPopulated()) {
+      // recompute the new values from the policy
+      foreach ($this->viewingRule->getUsers() as $account) {
+        $this->item->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
       }
+      foreach ($this->viewingRule->getRoles() as $role) {
+        $this->item->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+      }
+    }
 
-      if ($this->viewingRule->isPopulated()) {
+    if ($this->datastreamRule->isPopulated()) {
+      foreach ($this->datastreamRule->getDsids() as $dsid) {
         // recompute the new values from the policy
-        foreach ($this->viewingRule->getUsers() as $account) {
-          $this->item->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+        //XXX:  These use the RELS-EXT URI...
+        foreach ($this->datastreamRule->getUsers() as $account) {
+          $this->item->add_dsid_relationship($dsid, $viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
         }
-        foreach ($this->viewingRule->getRoles() as $role) {
-          $this->item->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
+        foreach ($this->datastreamRule->getRoles() as $role) {
+          $this->item->add_dsid_relationship($dsid, $viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
         }
-      }
-
-      if ($this->datastreamRule->isPopulated()) {
-        foreach ($this->datastreamRule->getDsids() as $dsid) {
-          // recompute the new values from the policy
-          foreach ($this->datastreamRule->getUsers() as $account) {
-            $this->item->add_dsid_relationship($dsid, $viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-          }
-          foreach ($this->datastreamRule->getRoles() as $role) {
-            $this->item->add_dsid_relationship($dsid, $viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-          }
-        } 
       }
     }
   }

--- a/api/IslandoraXacml.inc
+++ b/api/IslandoraXacml.inc
@@ -1,0 +1,46 @@
+<?php
+
+module_load_include('inc', 'islandora_xacml_api', 'Xacml');
+
+/**
+ * Subclass Xacml to facilitate communication to Islandora/Fedora.
+ * 
+ * Need to have Drupal bootstrapped, due to use of module_load_includes
+ */
+class IslandoraXacml extends Xacml {
+  /**
+   * The idenitfy the datastream from which this policy was obtained (and to
+   * which it should be written back to).
+   *
+   * @var $item
+   * @var $pid
+   * @var $dsid
+   */
+  protected $item, $pid, $dsid;
+  
+  function __construct($pid, $dsid = 'POLICY') {
+    module_load_include('inc', 'fedora_repository', 'api/fedora_item');
+    $item = new Fedora_Item($pid);
+    
+    $xacml = NULL;
+    if (isset($item->datastreams[$dsid])) {
+      $xacml = $item->get_datastream_dissemination($dsid);
+    }
+    
+    parent::_construct($xacml);
+    $this->pid = $pid;
+    $this->dsid = $dsid;
+    $this->item = $item;
+  }
+
+  function writeBackToFedora() {
+    $xml = $this->getXmlString();
+    if (array_key_exists($this->dsid, $this->item->datastreams)) {
+      return $this->item->modify_datastream($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml');
+    }
+    else {
+      return $this->item->add_datastream_from_string($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml', 'X');
+    }
+  }
+}
+

--- a/api/Xacml.inc
+++ b/api/Xacml.inc
@@ -133,6 +133,30 @@ abstract class XacmlRule {
   }
 
   /**
+   * Clear the settings for the given rule.
+   *
+   * @param $type
+   *   Either a type or array of types to clear, or NULL (something which casts
+   *   to an empty array) to clear all--except those values which are required--
+   *   from the rule array.
+   */
+  function clear($type = NULL) {
+    $dont_touch = array(
+      'ruleid',
+      'effect',
+    );
+
+    $clearable = array_diff(array_keys($this->rule), $dont_touch);
+    if (($types = (array)$type) && (count($types) > 0)) {
+      $clearable = array_intersect($clearable, $types);
+    }
+
+    foreach ($clearable as $to_clear) {
+      $this->rule[$to_clear] = array();
+    }
+  }
+
+  /**
    * Returns true if the rule is populated with data, otherwise returns false.
    *
    * For example a rule can be created that has no users or roles. This rule has no meaning

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -762,7 +762,7 @@ function islandora_xacml_editor_settings() {
     '#type' => 'checkbox',
     '#title' => t('Save policy details in RELS-EXT'),
     '#description' => t("Add <islandora:isViewableByUser> and <islandora:isViewableByRole> relationships to objects' RELS-EXT datastreams when XACML viewing restrictions are in place."),
-    '#default_value' => variable_get('islandora_xacml_editor_save_relationships', FALSE),
+    '#default_value' => variable_get('islandora_xacml_editor_save_relationships', TRUE),
   );
   $form['islandora_xacml_editor_show_dsidregex'] = array(
     '#type' => 'checkbox',
@@ -1544,7 +1544,7 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
   $object->purge_relationships($viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
   $object->purge_relationships($viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
 
-  if (variable_get('islandora_xacml_editor_save_relationships', FALSE) && $xacml->viewingRule->isPopulated()) {
+  if (variable_get('islandora_xacml_editor_save_relationships', TRUE) && $xacml->viewingRule->isPopulated()) {
     $values = $form_state['values']['access'];
     // recompute the new values from the policy
     if (isset($values['users'])) {

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -84,9 +84,9 @@ function islandora_xacml_editor_menu() {
 
 function islandora_xacml_editor_remove_js($xacml_dsid) {
   module_load_include('inc', 'php_lib', 'Ahah');
-  
+
   list($form_id, $form_build_id, $form, $form_state) = Ahah::getFormInfo();
-  
+
   // Get the values of the selects to keep them persistant across AHAH callbacks
   if (isset($_POST['dsidmime']['enabled'])) {
     $form_state['storage']['dsidmime']['enabled']['#value'] = TRUE;
@@ -94,59 +94,59 @@ function islandora_xacml_editor_remove_js($xacml_dsid) {
   else {
     $form_state['storage']['dsidmime']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($_POST['access']['enabled'])) {
     $form_state['storage']['access']['enabled']['#value'] = TRUE;
   }
   else {
     $form_state['storage']['access']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($form_state['post']['dsidmime']['users'])) {
     $form_state['storage']['dsidmime']['users'] = $form_state['post']['dsidmime']['users'];
   }
-  
+
   if (isset($form_state['post']['dsidmime']['roles'])) {
     $form_state['storage']['dsidmime']['roles'] = $form_state['post']['dsidmime']['roles'];
   }
-  
+
   if (isset($form_state['post']['manage']['users'])) {
     $form_state['storage']['manage']['users'] = $form_state['post']['manage']['users'];
   }
-  
+
   if (isset($form_state['post']['manage']['roles'])) {
     $form_state['storage']['manage']['roles'] = $form_state['post']['manage']['roles'];
   }
-  
+
   if (isset($form_state['post']['access']['users'])) {
     $form_state['storage']['access']['users'] = $form_state['post']['access']['users'];
   }
-  
+
   if (isset($form_state['post']['access']['roles'])) {
     $form_state['storage']['access']['roles'] = $form_state['post']['access']['roles'];
   }
-  
+
   $values = $form_state['storage']['dsidmime'];
-  
+
   if (isset($form_state['storage']['adddsid'])) {
     $values['dsid'] = array_merge($values['dsid'], $form_state['storage']['adddsid']);
   }
-  
+
   if (isset($form_state['storage']['addmime'])) {
     $values['mime'] = array_merge($values['mime'], $form_state['storage']['addmime']);
   }
-  
-  // Determine which button was pressed to initiate the AHAH callback. 
+
+  // Determine which button was pressed to initiate the AHAH callback.
   // The button naming conventions from the table function dictate that the portion
   // to the left of the --- is the filter type and to the right is the
   // corresponding row number. From this we get the row to remove.
   $removeval = array_search('Remove', $form_state['post']);
   $removeval = str_replace('~SPACE~', ' ', $removeval);
-  
+
   preg_match('/(.*)---(.*)/', $removeval, $match);
   $removeval = $match[2];
   $type = $match[1];
- 
+
   if ($type == 'DSID') {
     $form_state['storage']['removedsid'] = $form_state['storage']['rows'][$removeval]['Filter'];
   }
@@ -159,48 +159,48 @@ function islandora_xacml_editor_remove_js($xacml_dsid) {
   elseif ($type == 'DSID Regex') {
     $form_state['storage']['removedsidregex'] = $form_state['storage']['rows'][$removeval]['Filter'];
  }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $childvalue = $_POST['update_options'];
   }
-  
+
   $form_state['action'] = $form['#action'];
-  
+
   $tempvalues = $_POST;
-  
+
   $form = Ahah::rebuildForm($form_id, $form_build_id, $form, $form_state);
-  
+
   $form['dsidmime']['#collapsed'] = FALSE;
-  
+
   if (!empty($tempvalues['dsidmime']['newdsid'])) {
     $form['dsidmime']['newdsid']['#value'] = $tempvalues['dsidmime']['newdsid'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['newmime'])) {
     $form['dsidmime']['newmime']['#value'] = $tempvalues['dsidmime']['newmime'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['mimeregex'])) {
     $form['dsidmime']['mimeregex']['#value'] = $tempvalues['dsidmime']['mimeregex'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['dsidregex'])) {
     $form['dsidmime']['dsidregex']['#value'] = $tempvalues['dsidmime']['dsidregex'];
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options']['#value'] = $childvalue;
   }
-   
+
   Ahah::respond($form);
   exit();
 }
 
 function islandora_xacml_editor_add_dsid_regex_js($xacml_dsid, $pid) {
   module_load_include('inc', 'php_lib', 'Ahah');
-  
+
   list($form_id, $form_build_id, $form, $form_state) = Ahah::getFormInfo();
-  
+
   // Get the values of the selects to keep them persistant across AHAH callbacks
   if (isset($_POST['dsidmime']['enabled'])) {
     $form_state['storage']['dsidmime']['enabled']['#value'] = TRUE;
@@ -208,45 +208,45 @@ function islandora_xacml_editor_add_dsid_regex_js($xacml_dsid, $pid) {
   else {
     $form_state['storage']['dsidmime']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($_POST['access']['enabled'])) {
     $form_state['storage']['access']['enabled']['#value'] = TRUE;
   }
   else {
     $form_state['storage']['access']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($form_state['post']['dsidmime']['users'])) {
     $form_state['storage']['dsidmime']['users'] = $form_state['post']['dsidmime']['users'];
   }
-  
+
   if (isset($form_state['post']['dsidmime']['roles'])) {
     $form_state['storage']['dsidmime']['roles'] = $form_state['post']['dsidmime']['roles'];
   }
-  
+
   if (isset($form_state['post']['manage']['users'])) {
     $form_state['storage']['manage']['users'] = $form_state['post']['manage']['users'];
   }
-  
+
   if (isset($form_state['post']['manage']['roles'])) {
     $form_state['storage']['manage']['roles'] = $form_state['post']['manage']['roles'];
   }
-  
+
   if (isset($form_state['post']['access']['users'])) {
     $form_state['storage']['access']['users'] = $form_state['post']['access']['users'];
   }
-  
+
   if (isset($form_state['post']['access']['roles'])) {
     $form_state['storage']['access']['roles'] = $form_state['post']['access']['roles'];
   }
-  
+
   // Store and checks
-  
+
   if (!isset($form_state['storage']['dsidregexs'])) {
     $form_state['storage']['dsidregexs'] = array();
   }
   $addvalue = trim($_POST['dsidmime']['dsidregex']);
-  
+
   if (!empty($addvalue) && !ctype_space($addvalue)) {
   // Check the additional dsids and the dsids from the XACML rules
 
@@ -272,43 +272,43 @@ function islandora_xacml_editor_add_dsid_regex_js($xacml_dsid, $pid) {
   else {
     drupal_set_message(t('No DSID regex value entered!'), 'error');
   }
-      
+
   $form_state['action'] = $form['#action'];
   $tempvalues = $_POST;
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $childvalue = $_POST['update_options'];
   }
-  
+
   $form = Ahah::rebuildForm($form_id, $form_build_id, $form, $form_state);
- 
+
   $form['dsidmime']['#collapsed'] = FALSE;
-    
+
   if (!empty($tempvalues['dsidmime']['newmime'])) {
     $form['dsidmime']['newmime']['#value'] = $tempvalues['dsidmime']['newmime'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['mimeregex'])) {
     $form['dsidmime']['mimeregex']['#value'] = $tempvalues['dsidmime']['mimeregex'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['newdsid'])) {
     $form['dsidmime']['newdsid']['#value'] = $tempvalues['dsidmime']['newdsid'];
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options']['#value'] = $childvalue;
-  }  
-  
+  }
+
   Ahah::respond($form);
   exit();
 }
 
 function islandora_xacml_editor_add_dsid_js($xacml_dsid, $pid) {
   module_load_include('inc', 'php_lib', 'Ahah');
-  
+
   list($form_id, $form_build_id, $form, $form_state) = Ahah::getFormInfo();
-  
+
   // Get the values of the selects to keep them persistant across AHAH callbacks
   if (isset($_POST['dsidmime']['enabled'])) {
     $form_state['storage']['dsidmime']['enabled']['#value'] = TRUE;
@@ -316,38 +316,38 @@ function islandora_xacml_editor_add_dsid_js($xacml_dsid, $pid) {
   else {
     $form_state['storage']['dsidmime']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($_POST['access']['enabled'])) {
     $form_state['storage']['access']['enabled']['#value'] = TRUE;
   }
   else {
     $form_state['storage']['access']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($form_state['post']['dsidmime']['users'])) {
     $form_state['storage']['dsidmime']['users'] = $form_state['post']['dsidmime']['users'];
   }
-  
+
   if (isset($form_state['post']['dsidmime']['roles'])) {
     $form_state['storage']['dsidmime']['roles'] = $form_state['post']['dsidmime']['roles'];
   }
-  
+
   if (isset($form_state['post']['manage']['users'])) {
     $form_state['storage']['manage']['users'] = $form_state['post']['manage']['users'];
   }
-  
+
   if (isset($form_state['post']['manage']['roles'])) {
     $form_state['storage']['manage']['roles'] = $form_state['post']['manage']['roles'];
   }
-  
+
   if (isset($form_state['post']['access']['users'])) {
     $form_state['storage']['access']['users'] = $form_state['post']['access']['users'];
   }
-  
+
   if (isset($form_state['post']['access']['roles'])) {
     $form_state['storage']['access']['roles'] = $form_state['post']['access']['roles'];
   }
-    
+
   if (!isset($form_state['storage']['adddsid'])) {
     $form_state['storage']['adddsid'] = array();
   }
@@ -358,7 +358,7 @@ function islandora_xacml_editor_add_dsid_js($xacml_dsid, $pid) {
     if (isset($form_state['storage']['adddsid'])) {
       $added = array_search($addvalue, $form_state['storage']['adddsid']);
     }
-    
+
     if (isset($form_state['storage']['selecteddsid'])) {
       $rules = array_search($addvalue, $form_state['storage']['selecteddsid']);
     }
@@ -377,42 +377,42 @@ function islandora_xacml_editor_add_dsid_js($xacml_dsid, $pid) {
   else {
     drupal_set_message(t('No DSID value entered!'), 'error');
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $childvalue = $_POST['update_options'];
   }
-      
+
   $form_state['action'] = $form['#action'];
   $tempvalues = $_POST;
   $form = Ahah::rebuildForm($form_id, $form_build_id, $form, $form_state);
- 
+
   $form['dsidmime']['#collapsed'] = FALSE;
-    
+
   if (!empty($tempvalues['dsidmime']['newmime'])) {
     $form['dsidmime']['newmime']['#value'] = $tempvalues['dsidmime']['newmime'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['mimeregex'])) {
     $form['dsidmime']['mimeregex']['#value'] = $tempvalues['dsidmime']['mimeregex'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['dsidregex'])) {
     $form['dsidmime']['dsidregex']['#value'] = $tempvalues['dsidmime']['dsidregex'];
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options']['#value'] = $childvalue;
-  }  
-  
+  }
+
   Ahah::respond($form);
   exit();
 }
 
 function islandora_xacml_editor_add_mime_regex_js($xacml_dsid, $pid) {
   module_load_include('inc', 'php_lib', 'Ahah');
-  
+
   list($form_id, $form_build_id, $form, $form_state) = Ahah::getFormInfo();
-  
+
   // Get the values of the selects to keep them persistant across AHAH callbacks
   if (isset($_POST['dsidmime']['enabled'])) {
     $form_state['storage']['dsidmime']['enabled']['#value'] = TRUE;
@@ -420,56 +420,56 @@ function islandora_xacml_editor_add_mime_regex_js($xacml_dsid, $pid) {
   else {
     $form_state['storage']['dsidmime']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($_POST['access']['enabled'])) {
     $form_state['storage']['access']['enabled']['#value'] = TRUE;
   }
   else {
     $form_state['storage']['access']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($form_state['post']['dsidmime']['users'])) {
     $form_state['storage']['dsidmime']['users'] = $form_state['post']['dsidmime']['users'];
   }
-  
+
   if (isset($form_state['post']['dsidmime']['roles'])) {
     $form_state['storage']['dsidmime']['roles'] = $form_state['post']['dsidmime']['roles'];
   }
-  
+
   if (isset($form_state['post']['manage']['users'])) {
     $form_state['storage']['manage']['users'] = $form_state['post']['manage']['users'];
   }
-  
+
   if (isset($form_state['post']['manage']['roles'])) {
     $form_state['storage']['manage']['roles'] = $form_state['post']['manage']['roles'];
   }
-  
+
   if (isset($form_state['post']['access']['users'])) {
     $form_state['storage']['access']['users'] = $form_state['post']['access']['users'];
   }
-  
+
   if (isset($form_state['post']['access']['roles'])) {
     $form_state['storage']['access']['roles'] = $form_state['post']['access']['roles'];
   }
-  
+
   // Store and checks
-  
+
   if (!isset($form_state['storage']['mimeregexs'])) {
     $form_state['storage']['mimeregexs'] = array();
   }
-  
+
   $addvalue = trim($_POST['dsidmime']['mimeregex']);
-  
+
   if (!empty($addvalue) && !ctype_space($addvalue)) {
   // Check the additional dsids and the dsids from the XACML rules
     if (isset($form_state['storage']['mimeregexs'])) {
       $added = array_search($addvalue, $form_state['storage']['mimeregexs']);
     }
-    
+
     if (isset($form_state['storage']['selectedmimeregexs'])) {
       $rules = array_search($addvalue, $form_state['storage']['selectedmimeregexs']);
     }
-    
+
     if (!is_numeric($added) && $rules != $addvalue) {
       $form_state['storage']['mimeregexs'][] = $addvalue;
     }
@@ -483,43 +483,43 @@ function islandora_xacml_editor_add_mime_regex_js($xacml_dsid, $pid) {
   }
   else {
     drupal_set_message(t('No MIME type regex value entered!'), 'error');
-  }   
+  }
   $form_state['action'] = $form['#action'];
   $tempvalues = $_POST;
 
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $childvalue = $_POST['update_options'];
   }
-  
+
   $form = Ahah::rebuildForm($form_id, $form_build_id, $form, $form_state);
- 
+
   $form['dsidmime']['#collapsed'] = FALSE;
-    
+
   if (!empty($tempvalues['dsidmime']['newmime'])) {
     $form['dsidmime']['newmime']['#value'] = $tempvalues['dsidmime']['newmime'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['dsidregex'])) {
     $form['dsidmime']['dsidregex']['#value'] = $tempvalues['dsidmime']['dsidregex'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['newdsid'])) {
     $form['dsidmime']['newdsid']['#value'] = $tempvalues['dsidmime']['newdsid'];
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options']['#value'] = $childvalue;
-  }  
-  
+  }
+
   Ahah::respond($form);
   exit();
 }
 
 function islandora_xacml_editor_add_mime_js($xacml_dsid, $pid) {
   module_load_include('inc', 'php_lib', 'Ahah');
-    
+
   list($form_id, $form_build_id, $form, $form_state) = Ahah::getFormInfo();
-    
+
   // Get the values of the selects to keep them persistant across AHAH callbacks
   if (isset($_POST['dsidmime']['enabled'])) {
     $form_state['storage']['dsidmime']['enabled']['#value'] = TRUE;
@@ -527,44 +527,44 @@ function islandora_xacml_editor_add_mime_js($xacml_dsid, $pid) {
   else {
     $form_state['storage']['dsidmime']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($_POST['access']['enabled'])) {
     $form_state['storage']['access']['enabled']['#value'] = TRUE;
   }
   else {
     $form_state['storage']['access']['enabled']['#value'] = FALSE;
   }
-  
+
   if (isset($form_state['post']['dsidmime']['users'])) {
     $form_state['storage']['dsidmime']['users'] = $form_state['post']['dsidmime']['users'];
   }
-  
+
   if (isset($form_state['post']['dsidmime']['roles'])) {
     $form_state['storage']['dsidmime']['roles'] = $form_state['post']['dsidmime']['roles'];
   }
-  
+
   if (isset($form_state['post']['manage']['users'])) {
     $form_state['storage']['manage']['users'] = $form_state['post']['manage']['users'];
   }
-  
+
   if (isset($form_state['post']['manage']['roles'])) {
     $form_state['storage']['manage']['roles'] = $form_state['post']['manage']['roles'];
   }
-  
+
   if (isset($form_state['post']['access']['users'])) {
     $form_state['storage']['access']['users'] = $form_state['post']['access']['users'];
   }
-  
+
   if (isset($form_state['post']['access']['roles'])) {
     $form_state['storage']['access']['roles'] = $form_state['post']['access']['roles'];
   }
-  
+
   if (!isset($form_state['storage']['addmime'])) {
     $form_state['storage']['addmime'] = array();
   }
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
-    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');  
+    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');
 
     $collection = CollectionPolicy::loadFromCollection($pid);
     if ($collection) {
@@ -598,7 +598,7 @@ function islandora_xacml_editor_add_mime_js($xacml_dsid, $pid) {
 
     if (isset($form_state['storage']['selectedmime'])) {
       $rules = array_search($addvalue, $form_state['storage']['selectedmime']);
-    } 
+    }
 
     if (!is_numeric($added) && $rules != $addvalue) {
       $form_state['storage']['addmime'][] = $addvalue;
@@ -614,46 +614,46 @@ function islandora_xacml_editor_add_mime_js($xacml_dsid, $pid) {
   else {
     drupal_set_message(t('No MIME type value entered!'), 'error');
   }
- 
-  $form_state['action'] = $form['#action']; 
+
+  $form_state['action'] = $form['#action'];
   $tempvalues = $_POST;
-  
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $childvalue = $_POST['update_options'];
   }
-  
+
   $form = Ahah::rebuildForm($form_id, $form_build_id, $form, $form_state);
-  
+
   $form['dsidmime']['#collapsed'] = FALSE;
-    
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options']['#value'] = $childvalue;
   }
-  
+
   if (!empty($tempvalues['dsidmime']['newdsid'])) {
     $form['dsidmime']['newdsid']['#value'] = $tempvalues['dsidmime']['newdsid'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['mimeregex'])) {
     $form['dsidmime']['mimeregex']['#value'] = $tempvalues['dsidmime']['mimeregex'];
   }
-  
+
   if (!empty($tempvalues['dsidmime']['dsidregex'])) {
     $form['dsidmime']['dsidregex']['#value'] = $tempvalues['dsidmime']['dsidregex'];
   }
-  
+
   Ahah::respond($form);
   exit();
 }
 
 function islandora_xacml_editor_dsid_autocomplete($pid, $string) {
   module_load_include('inc', 'fedora_repository', 'api/fedora_item');
-  
+
   $object = new Fedora_Item($pid);
   $dslist = $object->get_datastreams_list_as_array();
-  
+
   $output = array();
-  
+
   foreach ($dslist as $key => $value) {
     if ($string != '*') {
       if (strpos(strtoupper($key), strtoupper($string)) !== false) {
@@ -664,17 +664,17 @@ function islandora_xacml_editor_dsid_autocomplete($pid, $string) {
       $output[$key] = check_plain($key);
     }
   }
-    
+
   print drupal_to_js($output);
   exit();
 }
 
 function islandora_xacml_editor_mime_autocomplete($xacml_dsid, $pid, $string) {
   module_load_include('inc', 'fedora_repository', 'ContentModel');
-  
+
   $output = array();
   if($xacml_dsid == 'CHILD_SECURITY') {
-    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');  
+    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');
 
     $collection = CollectionPolicy::loadFromCollection($pid);
     if ($collection) {
@@ -700,7 +700,7 @@ function islandora_xacml_editor_mime_autocomplete($xacml_dsid, $pid, $string) {
     }
   }
   foreach ($mime as $key => $value) {
-    if ($string != "*") { 
+    if ($string != "*") {
       if (strpos(strtoupper($key), strtoupper($string)) !== false) {
         $output[$key] = check_plain($key);
       }
@@ -709,10 +709,10 @@ function islandora_xacml_editor_mime_autocomplete($xacml_dsid, $pid, $string) {
       $output[$key] = check_plain($key);
     }
   }
-  
+
   print drupal_to_js($output);
   exit();
-   
+
 }
 
 /**
@@ -787,20 +787,20 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   module_load_include('inc', 'islandora_xacml_api', 'Xacml');
   module_load_include('inc', 'fedora_repository', 'ObjectHelper');
   module_load_include('inc', 'php_lib', 'Ahah');
-  
+
   Ahah::get_ahah_js();
   // when we call in from top level collections in JS get get the
   // pid being undefined
   if ($object_pid == 'undefined' || !$object_pid) {
     $object_pid = variable_get('fedora_repository_pid', 'islandora:top');
   }
-  
+
   if (!isset($form_state['storage'])) {
     $form_state['storage'] = array();
     $form_state['storage']['object_pid'] = $object_pid;
     $form_state['storage']['xacml_dsid'] = $xacml_dsid;
   }
-  
+
   if (!valid_pid($object_pid) || !valid_dsid($xacml_dsid)) {
     drupal_not_found();
     exit();
@@ -824,7 +824,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
   module_load_include('inc', 'fedora_repository', 'ContentModel');
 
   if ($xacml_dsid == 'CHILD_SECURITY') {
-    module_load_include('inc', 'fedora_repository', 'CollectionPolicy'); 
+    module_load_include('inc', 'fedora_repository', 'CollectionPolicy');
 
     $collection = CollectionPolicy::loadFromCollection($object_pid);
     if ($collection) {
@@ -908,7 +908,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#suffix' => '</div>',
   );
   $form['#cache'] = TRUE;
-  
+
   if (isset($form_state['action'])) {
     $form['#action'] = $form_state['action'];
   }
@@ -977,7 +977,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#size' => 10,
     '#suffix' => '</div>',
   );
-  
+
   $form['dsidmime'] = array(
     '#type' => 'fieldset',
     '#title' => t('Datastreams and MIME types'),
@@ -990,7 +990,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#title' => t('Enable XACML Restrictions on DSIDs and MIME types'),
     '#default_value' => isset($form_state['storage']['dsidmime']['enabled']) ? $form_state['storage']['dsidmime']['enabled']['#value'] : $xacml->datastreamRule->isPopulated(),
   );
-     
+
   if ($xacml_dsid == 'CHILD_SECURITY') {
     $form['update_options'] = array(
       '#type' => 'select',
@@ -1003,7 +1003,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       ),
     );
   }
-  
+
   $form['dsidmime']['users'] = array(
     '#type' => 'select',
     '#title' => t('Users'),
@@ -1023,97 +1023,97 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#size' => 10,
     '#suffix' => '</div>',
   );
-  
+
   // Grab these values to handle removal
   $tempmime = $xacml->datastreamRule->getMimetypes();
   $tempdsid = $xacml->datastreamRule->getDsids();
   $tempmimeregexs = $xacml->datastreamRule->getMimetypeRegexs();
   $tempdsidregexs = $xacml->datastreamRule->getDsidRegexs();
-      
+
   if (isset($form_state['storage']['removedsid'])) {
     $key = array_search($form_state['storage']['removedsid'], $tempdsid);
-    
+
     // If the value is not one of our 'hidden DSIDs'
     if (is_numeric($key)) {
       $xacml->datastreamRule->removeDsid($tempdsid[$key]);
       $form_state['storage']['hidedsids'][] = $form_state['storage']['removedsid'];
-    }  
-       
+    }
+
     $dsid = $form_state['storage']['removedsid'];
     unset($form_state['storage']['removedsid']);
-    
+
     if (isset($form_state['storage']['adddsid'])) {
       $search = array_search($dsid, $form_state['storage']['adddsid']);
-      
+
       if (is_numeric($search)) {
         unset($form_state['storage']['adddsid'][$search]);
       }
     }
   }
-  
+
   if (isset($form_state['storage']['removemime'])) {
     $key = array_search($form_state['storage']['removemime'], $tempmime);
-    
+
     // If the value is not one of our 'hidden mimes'
     if (is_numeric($key)) {
       $xacml->datastreamRule->removeMimetype($tempmime[$key]);
       $form_state['storage']['hidemimes'][] = $form_state['storage']['removemime'];
     }
-        
+
     $mime = $form_state['storage']['removemime'];
     unset($form_state['storage']['removemime']);
-    
+
     if (isset($form_state['storage']['addmime'])) {
       $search = array_search($mime, $form_state['storage']['addmime']);
-      
+
       if (is_numeric($search)) {
         unset($form_state['storage']['addmime'][$search]);
       }
     }
   }
-  
+
   if (isset($form_state['storage']['removemimeregex'])) {
     $key = array_search($form_state['storage']['removemimeregex'], $tempmimeregexs);
-    
+
     // If the value is not one of our 'hidden mime regexs'
     if (is_numeric($key)) {
       $xacml->datastreamRule->removeMimetypeRegex($tempmimeregexs[$key]);
       $form_state['storage']['hidemimeregexs'][] = $form_state['storage']['removemimeregex'];
     }
-        
+
     $mime = $form_state['storage']['removemimeregex'];
     unset($form_state['storage']['removemimeregex']);
-    
+
     if (isset($form_state['storage']['mimeregexs'])) {
       $search = array_search($mime, $form_state['storage']['mimeregexs']);
-      
+
       if (is_numeric($search)) {
         unset($form_state['storage']['mimeregexs'][$search]);
       }
     }
   }
-  
+
   if (isset($form_state['storage']['removedsidregex'])) {
     $key = array_search($form_state['storage']['removedsidregex'], $tempdsidregexs);
-    
+
     // If the value is not one of our 'hidden mimes'
     if (is_numeric($key)) {
       $xacml->datastreamRule->removeDsidRegex($tempdsidregexs[$key]);
       $form_state['storage']['hidedsidregexs'][] = $form_state['storage']['removedsidregex'];
     }
-        
+
     $dsid = $form_state['storage']['removedsidregex'];
     unset($form_state['storage']['removedsidregex']);
-    
+
     if (isset($form_state['storage']['dsidregexs'])) {
       $search = array_search($dsid, $form_state['storage']['dsidregexs']);
-      
+
       if (is_numeric($search)) {
         unset($form_state['storage']['dsidregexs'][$search]);
       }
     }
   }
-    
+
   // If we are carrying values from the original rule that need to be removed
   // remove them.
   if (isset($form_state['storage']['hidemimes'])) {
@@ -1121,42 +1121,42 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       $xacml->datastreamRule->removeMimetype($value);
     }
   }
-  
+
   if (isset($form_state['storage']['hidedsids'])) {
     foreach ($form_state['storage']['hidedsids'] as $key => $value) {
       $xacml->datastreamRule->removeDsid($value);
     }
   }
-  
+
   if (isset($form_state['storage']['hidemimeregexs'])) {
     foreach ($form_state['storage']['hidemimeregexs'] as $key => $value) {
       $xacml->datastreamRule->removeMimetypeRegex($value);
     }
   }
-  
+
   if (isset($form_state['storage']['hidedsidregexs'])) {
     foreach ($form_state['storage']['hidedsidregexs'] as $key => $value) {
       $xacml->datastreamRule->removeDsidRegex($value);
     }
   }
-  
+
   // Grab the updated values to handle addition of rules.
   $tempmime = $xacml->datastreamRule->getMimetypes();
   $tempdsid = $xacml->datastreamRule->getDsids();
   $tempmimeregexs = $xacml->datastreamRule->getMimetypeRegexs();
   $tempdsidregexs = $xacml->datastreamRule->getDsidRegexs();
-  
+
   // Add any values we are carrying in the form storage to the datastream rules
   if (isset($form_state['storage']['adddsid'])) {
     foreach ($form_state['storage']['adddsid'] as $key => $value) {
       $search = array_search($value, $tempdsid);
-      
+
       if (!is_numeric($search)) {
         $xacml->datastreamRule->addDsid($value);
-        
+
         if (isset($form_state['storage']['hidedsids'])) {
           $removedsid = array_search($value, $form_state['storage']['hidedsids']);
-          
+
           if (is_numeric($removedsid)) {
             unset($form_state['storage']['hidesids'][$removedsid]);
           }
@@ -1164,17 +1164,17 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       }
     }
   }
-  
+
   if (isset($form_state['storage']['addmime'])) {
     foreach ($form_state['storage']['addmime'] as $key => $value) {
       $search = array_search($value, $tempmime);
-      
+
       if (!is_numeric($search)) {
         $xacml->datastreamRule->addMimetype($value);
-        
+
         if (isset($form_state['storage']['hidemimes'])) {
           $removemime = array_search($value, $form_state['storage']['hidemimes']);
-          
+
           if (is_numeric($removemime)) {
             unset($form_state['storage']['hidemimes'][$removemime]);
           }
@@ -1182,86 +1182,86 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       }
     }
   }
-    
+
   if (isset($form_state['storage']['dsidregexs'])) {
     foreach ($form_state['storage']['dsidregexs'] as $key => $value) {
       $search = array_search($value, $tempdsidregexs);
-      
+
       if (!is_numeric($search)) {
         $xacml->datastreamRule->addDsidRegex($value);
-        
+
         if (isset($form_state['storage']['hidedsidregexs'])) {
           $removedsid = array_search($value, $form_state['storage']['hidedsidregexs']);
-          
+
           if (is_numeric($removedsid)) {
             unset($form_state['storage']['hidedsidregexs'][$removedsid]);
           }
         }
       }
     }
-  }  
- 
+  }
+
   if (isset($form_state['storage']['mimeregexs'])) {
     foreach ($form_state['storage']['mimeregexs'] as $key => $value) {
       $search = array_search($value, $tempmimeregexs);
-      
+
       if (!is_numeric($search)) {
         $xacml->datastreamRule->addMimetypeRegex($value);
-        
+
         if (isset($form_state['storage']['hidemimeregexs'])) {
           $removemime = array_search($value, $form_state['storage']['hidemimeregexs']);
-          
+
           if (is_numeric($removemime)) {
             unset($form_state['storage']['hidemimeregexs'][$removemime]);
           }
         }
       }
     }
-  } 
-  
+  }
+
   // Grab the values one last time for storage and use in constructing the
   // rules table.
   $selectedmime = $xacml->datastreamRule->getMimetypes();
   $selecteddsid = $xacml->datastreamRule->getDsids();
   $selectedmimeregexs = $xacml->datastreamRule->getMimetypeRegexs();
   $selecteddsidregexs = $xacml->datastreamRule->getDsidRegexs();
-  
+
   // We store these values for use in the AHAH callbacks
   $form_state['storage']['dsidmime']['dsid'] = $selecteddsid;
   $form_state['storage']['dsidmime']['mime'] = $selectedmime;
   $form_state['storage']['dsidmime']['dsidregexs'] = $selecteddsidregexs;
   $form_state['storage']['dsidmime']['mimeregexs'] = $selectedmimeregexs;
-  
+
   if (count($selectedmime) > 0) {
     $form_state['storage']['selectedmime'] = array_combine($selectedmime, $selectedmime);
   }
   else {
     unset($form_state['storage']['selectedmime']);
   }
-  
+
   if (count($selecteddsid) > 0) {
     $form_state['storage']['selecteddsid'] = array_combine($selecteddsid, $selecteddsid);
   }
   else {
     unset($form_state['storage']['selecteddsid']);
   }
-  
+
   if (count($selectedmimeregexs) > 0) {
     $form_state['storage']['selectedmimeregexs'] = array_combine($selectedmimeregexs, $selectedmimeregexs);
   }
   else {
     unset($form_state['storage']['selectedmimeregexs']);
   }
-  
+
   if (count($selecteddsidregexs) > 0) {
     $form_state['storage']['selecteddsidregexs'] = array_combine($selecteddsidregexs, $selecteddsidregexs);
   }
   else {
     unset($form_state['storage']['selecteddsidregexs']);
   }
-  
+
   $rows = array();
-  
+
   if (!empty($selectedmime)) {
     foreach ($selectedmime as $mime) {
       $rows[] = array(
@@ -1270,7 +1270,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       );
     }
   }
-    
+
   if (!empty($selectedmimeregexs)) {
     foreach ($selectedmimeregexs as $mimeregex) {
       $rows[] = array(
@@ -1279,7 +1279,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       );
     }
   }
-  
+
   if (!empty($selecteddsid)) {
     foreach ($selecteddsid as $dsid) {
       $rows[] = array(
@@ -1288,7 +1288,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       );
     }
   }
-    
+
   if (!empty($selecteddsidregexs)) {
     foreach ($selecteddsidregexs as $dsidregex) {
       $rows[] = array(
@@ -1297,15 +1297,15 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       );
     }
   }
-  
+
   $form_state['storage']['rows'] = $rows;
-  
+
   $form['dsidmime']['table'] = array(
     '#type' => 'item',
     '#value' => (count($rows) > 0) ? '<strong>Applied Rules:</strong>' : '<strong>No rules applied!</strong>',
     'table' => islandora_xacml_editor_form_table($rows, $xacml_dsid),
   );
-  
+
   $form['dsidmime']['newdsid'] = array(
     '#type' => 'textfield',
     '#title' => t('DSID'),
@@ -1325,7 +1325,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       'method' => 'replace',
     ),
   );
-  
+
   if (variable_get('islandora_xacml_editor_show_dsidregex', 1)) {
     $form['dsidmime']['dsidregex'] = array(
       '#type' => 'textfield',
@@ -1365,7 +1365,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
       'method' => 'replace',
     ),
   );
-  
+
   if (variable_get('islandora_xacml_editor_show_mimeregex', 1)) {
     $form['dsidmime']['mimeregex'] = array(
       '#type' => 'textfield',
@@ -1390,7 +1390,7 @@ function islandora_xacml_editor_page(&$form_state, $object_pid, $xacml_dsid) {
     '#type' => 'submit',
     '#value' => t('Set Permissions'),
   );
-   
+
   return $form;
 }
 
@@ -1453,7 +1453,7 @@ function islandora_xacml_editor_form_table(array $selected, $xacml_dsid) {
         ),
       )
     );
-    $count++;    
+    $count++;
   }
   return $table;
 }
@@ -1485,88 +1485,61 @@ function islandora_xacml_editor_page_submit(&$form, &$form_state) {
   module_load_include('inc', 'islandora_xacml_api', 'Xacml');
   module_load_include('inc', 'fedora_repository', 'api/fedora_item');
 
-  $xacml = new Xacml();
+  $pid = $form_state['storage']['object_pid'];
+  $dsid = $form_state['storage']['xacml_dsid'];
+  $xacml = new IslandoraXacml($pid, $dsid);
 
   // check datastreams and mime
   $values = $form_state['values']['dsidmime'];
-  
+
   if ($values['enabled']) {
+    $xacml->datastreamRule->clear();
+
     if ($form_state['storage']['selectedmime']) {
       $xacml->datastreamRule->addMimetype($form_state['storage']['selectedmime']);
     }
-    
+
     if ($form_state['storage']['selecteddsid']) {
       $xacml->datastreamRule->addDsid($form_state['storage']['selecteddsid']);
     }
-    
+
     if ($form_state['storage']['selectedmimeregexs']) {
       $xacml->datastreamRule->addMimetypeRegex($form_state['storage']['selectedmimeregexs']);
     }
-    
+
     if ($form_state['storage']['selecteddsidregexs']) {
       $xacml->datastreamRule->addDsidRegex($form_state['storage']['selecteddsidregexs']);
     }
-    
+
     $xacml->datastreamRule->addUser($values['users']);
     $xacml->datastreamRule->addRole($values['roles']);
   }
 
   // check admin (always have this rule)
   $values = $form_state['values']['manage'];
+  $xacml->managementRule->clear();
   $xacml->managementRule->addUser($values['users']);
   $xacml->managementRule->addRole($values['roles']);
 
   // check access
   $values = $form_state['values']['access'];
   if ($values['enabled']) {
+    $xacml->viewingRule->clear();
     $xacml->viewingRule->addUser($values['users']);
     $xacml->viewingRule->addRole($values['roles']);
   }
- 
-  $xml = $xacml->getXmlString();
-  $pid = $form_state['storage']['object_pid'];
-  $dsid = $form_state['storage']['xacml_dsid'];
 
-  $object = new Fedora_Item($pid);
-  $datastreams = $object->get_datastreams_list_as_array();
-
-  if (array_key_exists($dsid, $datastreams)) {
-    $object->modify_datastream_by_value($xml, $dsid, 'Xacml Policy Stream', 'text/xml');
-  }
-  else {
-    $object->add_datastream_from_string($xml, $dsid, 'Xacml Policy Stream', 'text/xml', 'X');
-  }
-  
-  // save relationships before $form_state['storage'] gets scrubbed, removing the object's PID
-  $viewable_by_user = 'isViewableByUser';
-  $viewable_by_role = 'isViewableByRole';
-  // remove all old policy related rels-ext statements
-  $object->purge_relationships($viewable_by_user, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-  $object->purge_relationships($viewable_by_role, NULL, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-
-  if (variable_get('islandora_xacml_editor_save_relationships', TRUE) && $xacml->viewingRule->isPopulated()) {
-    $values = $form_state['values']['access'];
-    // recompute the new values from the policy
-    if (isset($values['users'])) {
-      foreach ($values['users'] as $account) {
-        $object->add_relationship($viewable_by_user, $account, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-      }
-    }
-    if (isset($values['roles'])) {
-      foreach ($values['roles'] as $role) {
-        $object->add_relationship($viewable_by_role, $role, ISLANDORA_RELS_EXT_URI, RELS_TYPE_PLAIN_LITERAL);
-      }
-    }
-  }
+  $xacml->writeBackToFedora();
 
   if ($dsid == 'CHILD_SECURITY' && $form_state['values']['update_options'] != 'newchildren') {
     $option = $form_state['values']['update_options'];
+    $xml = $xacml->getXmlString();
     $batch = array(
       'title' => t('Updating Policies'),
       'progress_message' => t('Please wait if many objects are being updated this could take a few minutes.'),
       'operations' => array(
         array(
-          'islandora_xacml_editor_batch_function', 
+          'islandora_xacml_editor_batch_function',
           array($xml, $pid, $option)
         ),
       ),
@@ -1675,6 +1648,8 @@ class IslandoraUpdatePolicy {
   protected $pid;
 
   function __construct($pid, $xml) {
+    //Used at a couple different points...  Let's just load this here?
+    module_load_include('inc', 'islandora_xacml_api', 'IslandoraXacml');
     $this->pid = $pid;
     $this->xml = $xml;
     $this->object = new Fedora_Item($pid);
@@ -1706,39 +1681,29 @@ class IslandoraUpdatePolicy {
     global $user;
     $success = FALSE;
     if ($this->object->exists()) {
-      $datastreams = $this->object->get_datastreams_list_as_array();
-      if (array_key_exists('POLICY', $datastreams)) {
-        try {
-          $xacml = Xacml::constructFromPid($this->pid);
-          if ($xacml->managementRule->hasPermission($user->name, $user->roles)) {
-            $success = $this->addOrUpdateAllPolicies($datastreams);
-          }
-        }
-        catch (XacmlException $e) {
+      try {
+        $xacml = new IslandoraXacml($this->pid, 'POLICY');
+        if ($xacml->managementRule->hasPermission($user->name, $user->roles)) {
+          $success = $this->addOrUpdateAllPolicies();
         }
       }
-      else {
-        $success = $this->addOrUpdateAllPolicies($datastreams);
+      catch (XacmlException $e) {
       }
     }
     return $success;
   }
 
-  private function addOrUpdateAllPolicies($datastreams) {
-    $ret = $this->addOrUpdatePolicy($datastreams, 'POLICY');
-    if ($this->isCollection()) {
-      $ret &= $this->addOrUpdatePolicy($datastreams, 'CHILD_SECURITY');
-    }
-    return $ret;
-  }
+  private function addOrUpdateAllPolicies() {
+    module_load_include('inc', 'islandora_xacml_api', 'IslandoraXacml');
+    $object_policy = new IslandoraXacml($this->pid, 'POLICY', $this->xml);
+    $object_policy->writeBackToFedora();
 
-  private function addOrUpdatePolicy($datastreams, $dsid) {
-    if (array_key_exists($dsid, $datastreams)) {
-      return $this->object->modify_datastream_by_value($this->xml, $dsid, 'Xacml Policy Stream', 'text/xml');
+    if ($this->isCollection()) {
+      $child_policy = new IslandoraXacml($this->pid, 'CHILD_SECURIRY', $this->xml);
+      $child_policy->writeBackToFedora();
     }
-    else {
-      return $this->object->add_datastream_from_string($this->xml, $dsid, 'Xacml Policy Stream', 'text/xml', 'X');
-    }
+
+    return TRUE;
   }
 }
 


### PR DESCRIPTION
Add Islandora/Fedora oriented wrapper for the Xacml class--is instantiated with a PID (and possibly a DSID), and a method can cause it to be written back out to the given DSID.

Also, I've made it such that the relationships are written by default...  Given that we're to have stuff (embargo, and filtering of Solr results) happening in the API alone, without using the editor, this seemed necessary.
