### PR TITLE
Prevent actions from getting cleared.

### DIFF
--- a/api/Xacml.inc
+++ b/api/Xacml.inc
@@ -146,6 +146,7 @@ abstract class XacmlRule {
     $dont_touch = array(
       'ruleid',
       'effect',
+      'methods',
     );
 
     $clearable = array_diff(array_keys($this->rule), $dont_touch);


### PR DESCRIPTION
Actually referred to in code as "methods," but anyway.
