### PR TITLE
Rename and move the configuration for a Drupal variable

### DIFF
--- a/api/IslandoraXacml.inc
+++ b/api/IslandoraXacml.inc
@@ -57,10 +57,8 @@ class IslandoraXacml extends Xacml {
       $this->item->add_datastream_from_string($xml, $this->dsid, 'Xacml Policy Stream', 'text/xml', 'X');
     }
 
-
-
     //Only add relationships on POLICY datastream, as only the POLICY is enforced.
-    if ($this->dsid == 'POLICY' && variable_get('islandora_xacml_editor_save_relationships', TRUE)) {
+    if ($this->dsid == 'POLICY' && variable_get('islandora_xacml_api_save_relationships', TRUE)) {
       $this->writeRelations();
     }
     return TRUE;

--- a/api/islandora_xacml_api.install
+++ b/api/islandora_xacml_api.install
@@ -31,3 +31,28 @@ function islandora_xacml_api_update_6001() {
       array('success' => TRUE, 'query' => 'Islandora XACML Solr variables updated.'),
     );
 }
+
+/**
+ * Implements hook_update_N().
+ *
+ * This function will help fix an issue where the dependent islandora_xacml_editor
+ * module set variables that are only used in this module.
+ * The issue would require the islandora_xacml_editor module to be enabled to
+ * alter this variable.  It is desirable for some users to customize these
+ * variables but not enable the islandora_xacml_editor, so management of these
+ * variables is being passed to islandora_xacml_api.
+ */
+function islandora_xacml_api_update_6002() {
+  // Get current variable value.
+  $set_relationships = variable_get('islandora_xacml_editor_save_relationships', TRUE);
+
+  // Set new variable.
+  variable_set('islandora_xacml_api_save_relationships', $viewable_by_user);
+
+  // Kill old variable.
+  variable_del('islandora_xacml_editor_save_relationships');
+
+  return array(
+    array('success' => TRUE, 'query' => 'Islandora XACML relationships variable updated.'),
+  );
+}

--- a/api/islandora_xacml_api.module
+++ b/api/islandora_xacml_api.module
@@ -53,6 +53,12 @@ function islandora_xacml_api_settings() {
     '#title' => t('Solr RELS-EXT ViewableByRole field'),
     '#default_value' => variable_get('islandora_xacml_api_rels_viewable_role', 'RELS_EXT_isViewableByRole_literal_ms'),
   );
+  $form['islandora_xacml_api_save_relationships'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Save relationships'),
+    '#description' => t('Causes relationships to be written to the REL-INT/EXT when the policy is saved. (required to make use of the Solr field values above)'),
+    '#default_value' => variable_get('islandora_xacml_api_save_relationships', TRUE),
+  );
 
   return system_settings_form($form);
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -818,12 +818,6 @@ function islandora_xacml_editor_settings() {
     '#description' => t("Show a tab for the XACML Policy Editor on each Fedora item's page. For normal items, this policy will only apply to the item itself; in the case of collection items (having the content model &lt;islandora:collectionCModel&gt;), this will be a child policy."),
     '#default_value' => variable_get('islandora_xacml_editor_show_tabs', 1),
   );
-  $form['islandora_xacml_editor_save_relationships'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Save policy details in RELS-EXT'),
-    '#description' => t("Add <islandora:isViewableByUser> and <islandora:isViewableByRole> relationships to objects' RELS-EXT datastreams when XACML viewing restrictions are in place."),
-    '#default_value' => variable_get('islandora_xacml_editor_save_relationships', TRUE),
-  );
   $form['islandora_xacml_editor_show_dsidregex'] = array(
     '#type' => 'checkbox',
     '#title' => t('Display the DSID regex textfield?'),


### PR DESCRIPTION
The "islandora_xacml_editor_save_relationships" variable is only used
in the API code, and since we have a config page for the API,
a move seemed logical.  Renamed the variable to
"islandora_xacml_api_save_relationships" to reflect this.
