### PR TITLE
Updated how Object is stored in XACML forms

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -179,7 +179,7 @@ function islandora_xacml_editor_form($form, &$form_state, $object) {
 
   if (!isset($form_state['islandora_xacml'])) {
     $form_state['islandora_xacml'] = array();
-    $form_state['islandora_xacml']['object'] = $object;
+    $form_state['islandora_xacml']['pid'] = $object->id;
   }
 
   if (!islandora_is_valid_pid($object->id)) {
@@ -389,7 +389,7 @@ function islandora_xacml_editor_form($form, &$form_state, $object) {
   if (isset($form_state['triggering_element'])) {
     // Add DSID.
     if ($form_state['triggering_element']['#name'] == 'dsid_add_button' || $form_state['triggering_element']['#name'] == 'dsid_add_textfield') {
-      $object = $form_state['islandora_xacml']['object'];
+      $object = islandora_object_load($form_state['islandora_xacml']['pid']);
 
       if (!isset($form_state['islandora_xacml']['add_dsid'])) {
         $form_state['islandora_xacml']['add_dsid'] = array();
@@ -1187,7 +1187,7 @@ function islandora_xacml_editor_form_validate(&$form, &$form_state) {
  * The submit function where all the XACML magic happens. Abracadabra.
  */
 function islandora_xacml_editor_form_submit(&$form, &$form_state) {
-  $object = $form_state['islandora_xacml']['object'];
+  $object = islandora_object_load($form_state['islandora_xacml']['pid']);
   $pid = $object->id;
   $xacml = new IslandoraXacml($object);
 


### PR DESCRIPTION
Before the object was being stored in the form state. When the object
was unserialized in the submit function it was a different object
then the one loaded by islandora_load_object. This lead to inconsistancy
when the RELS-INT was updated on one object but not the other, since
they had seperate caches.

This was fixed in this commit, by passing the pid to be serialized
and then reloading the object using islandora_object_load when it
is needed, so we have a consistant copy in all places.

This may lead to a discussion about how we implement caching, but
this will fix the problem while we think about a larger solution.
