### PR TITLE
Manage xacml

### DIFF
--- a/api/islandora_xacml_api.module
+++ b/api/islandora_xacml_api.module
@@ -105,6 +105,78 @@ function islandora_xacml_api_islandora_solr_query($islandora_solr_query) {
 }
 
 /**
+ * Implements hook_islandora_datastream_purged().
+ */
+function islandora_xacml_editor_islandora_datastream_purged(AbstractObject $object, $dsid) {
+  $viewable_by_user = 'isViewableByUser';
+  $viewable_by_role = 'isViewableByRole';
+  $manageable_by_user = 'isManageableByUser';
+  $manageable_by_role = 'isManageableByRole';
+  // The XACML POLICY is removed.
+  if ($dsid === 'POLICY') {
+    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_user);
+    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_role);
+    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_user);
+    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_role);
+    foreach ($object as $dsid => $value) {
+      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
+      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
+      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_user);
+      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
+    }
+  }
+  else {
+    // An individual datastream is removed.
+    if (isset($object['POLICY'])) {
+      $xacml = new IslandoraXacml($object);
+      $ds_rule = $xacml->datastreamRule->getRuleArray();
+      if (array_search($dsid, $ds_rule['dsids']) !== FALSE) {
+        if (count($ds_rule['users']) > 0) {
+          $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
+        }
+        if (count($ds_rule['roles']) > 0) {
+          $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_islandora_datastream_ingested().
+ */
+function islandora_xacml_editor_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
+  if (isset($object['POLICY'])) {
+    $xacml = new IslandoraXacml($object);
+    $ds_rule = $xacml->datastreamRule->getRuleArray();
+    if (array_search($datastream->id, $ds_rule['dsids']) !== FALSE) {
+      $viewable_by_user = 'isViewableByUser';
+      $viewable_by_role = 'isViewableByRole';
+      $manageable_by_user = 'isManageableByUser';
+      $manageable_by_role = 'isManageableByRole';
+      if (count($ds_rule['users']) > 0) {
+        foreach ($ds_rule['users'] as $user) {
+          // The XACML API adds fedoraAdmin to the list of users as to prevent
+          // an object from being completely locked out. As this role is a
+          // Fedora role and has no interaction with Drupal we won't add it for
+          // cleanliness sake.
+          if ($user !== 'fedoraAdmin') {
+            $object[$datastream->id]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_user, $user, TRUE);
+            $object[$datastream->id]->relationships->add(ISLANDORA_RELS_EXT_URI, $manageable_by_user, $user, TRUE);
+          }
+        }
+      }
+      if (count($ds_rule['roles']) > 0) {
+        foreach ($ds_rule['roles'] as $role) {
+          $object[$datastream->id]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_role, $role, TRUE);
+          $object[$datastream->id]->relationships->add(ISLANDORA_RELS_EXT_URI, $manageable_by_role, $role, TRUE);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_islandora_basic_collection_query_get_query_statements().
  */
 function islandora_xacml_api_islandora_basic_collection_get_query_statements($type) {

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -1081,6 +1081,44 @@ function islandora_xacml_editor_form_submit(&$form, &$form_state) {
 }
 
 /**
+ * Theme the xacml policy management table.
+ *
+ * @param array $variables
+ *   Variables passed to this theme function.
+ *
+ * @return string
+ *   Markup representing the table for rendering.
+ */
+function theme_islandora_xacml_editor_policy_management_table(array $variables) {
+  // Manually add the table select javascript as we are using a custom table.
+  drupal_add_js('misc/tableselect.js');
+  $table = $variables['table'];
+  $row_elements = $table['rows'];
+  $rows = array();
+  foreach (element_children($row_elements) as $key) {
+    $columns = array();
+    $row_element = $row_elements[$key];
+    foreach (element_children($row_element) as $key) {
+      $column_element = $row_element[$key];
+      $columns[] = array(
+        'data' => drupal_render($column_element),
+        'class' => isset($cell_element['#attributes']['class']) ? $column_element['#attributes']['class'] : NULL,
+      );
+    }
+    $rows[] = $columns;
+  }
+  $variables = array(
+    'header' => $table['#header'],
+    'rows' => $rows,
+    'attributes' => $table['#attributes'],
+    'caption' => NULL,
+    'colgroups' => NULL,
+    'sticky' => NULL,
+    'empty' => t("No child collection(s)."),
+  );
+  return theme('table', $variables);
+}
+/**
  * AJAX callback to remove the selected filters from the rules table.
  */
 function islandora_xacml_editor_remove_selected($form, $form_state) {

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -332,7 +332,6 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
 function islandora_xacml_editor_after_build($form, &$form_state) {
   $form['xacml']['#weight'] = $form['next']['#weight'] - .001;
   unset($form['#sorted']);
-  dsm($form);
   return $form;
 }
 

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -42,7 +42,7 @@ function islandora_xacml_editor_menu() {
     'weight' => 0,
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_xacml_editor_form', 2),
-    'access callback' => array('administer islandora_xacml_editor'),
+    'access callback' => 'islandora_xacml_editor_access',
     'access arguments' => array(2),
     'file' => 'includes/form.inc',
   );
@@ -90,9 +90,6 @@ function islandora_xacml_editor_access($object) {
   return islandora_object_access('administer islandora_xacml_editor', $object);
 }
 
-function islandora_xacml_editor_manage_inheritance($object) {
-  return islandora_object_access(ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION, $object);
-}
 /**
  * Implements hook_islandora_object_access().
  */
@@ -300,7 +297,6 @@ function islandora_xacml_editor_islandora_basic_collection_build_manage_object(a
     'form' => drupal_get_form('islandora_xacml_editor_manage_xacml_form', $object),
   );
   $form_state['manage_collection_object']['manage_xacml']['form']['#submit'][] = 'islandora_xacml_editor_manage_xacml_form_submit';
-
   return $form_state;
 }
 
@@ -427,7 +423,7 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
 function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$form_state) {
   $child_pids = array_keys($form_state['values']['table']['rows']);
   $count = 0;
-  $message = "Complete: " . "\n";
+  $message = "Complete: \n";
   foreach ($form_state['values']['table']['rows'] as $row) {
     // Check if selected.
     if ($row['selected'] > 0) {
@@ -472,5 +468,5 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
     }
     $count++;
   }
-  drupal_set_message(t($message,'status'));
+  drupal_set_message(t('@message', array('@message' => $message), 'status'));
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -361,7 +361,6 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
 function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$form_state) {
   $child_pids = array_keys($form_state['values']['table']['rows']);
   $count = 0;
-  $message = "Complete: \n";
   foreach ($form_state['values']['table']['rows'] as $row) {
     // Check if selected.
     if ($row['selected'] > 0) {
@@ -369,9 +368,9 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
       // Are we adding the XACML POLICY or removing it? Just
       // check for a valid fedora object.
       if ($parent_object) {
+        $object = islandora_object_load($child_pids[$count]);
         // Make sure there is a POLICY to inherit.
         if ($parent_object['POLICY']) {
-          $object = islandora_object_load($child_pids[$count]);
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -14,7 +14,17 @@ function islandora_xacml_editor_permission() {
     ),
   );
 }
-
+/**
+ * Implements hook_theme().
+ */
+function islandora_xacml_editor_theme($existing, $type, $theme, $path) {
+  return array(
+    'islandora_xacml_editor_policy_management_table' => array(
+      'file' => 'includes/form.inc',
+      'render element' => 'table',
+    ),
+  );
+}
 /**
  * Implements hook_menu().
  */
@@ -216,14 +226,18 @@ function islandora_xacml_editor_islandora_ingest_steps(array $form_state) {
  */
 function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
   $parent_object = islandora_object_load($parent);
-  if ($parent_object['POLICY'] && $form_state['input']['xacml'] != 'None') {
+  if ((!isset($form_state['input']['xacml']) && $parent_object['POLICY']) ||
+    ($parent_object['POLICY'] && $form_state['input']['xacml'] != 'None')) {
     foreach ($form_state['islandora']['objects'] as $object) {
       // Need to update the RELS-INT to indicate which parent this policy is
       // inherited from.
-      $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent, TRUE);
+      $object->relationships->add(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent, TRUE);
       $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
       $xacml->writeBackToFedora();
     }
+  }
+  if (!isset($parent_object['POLICY'])) {
+    drupal_set_message(t("Parent $parent does not contain an xacml policy."), 'status');
   }
 }
 
@@ -257,7 +271,7 @@ function islandora_xacml_editor_undo_policy(&$form_state) {
 }
 
 /**
- * Implements islandora_build_manage_object_hook().
+ * Implements islandora_basic_collection_build_manage_object().
  *
  * @param array $form_state
  *   The current Form State being processed.
@@ -267,7 +281,7 @@ function islandora_xacml_editor_undo_policy(&$form_state) {
  * @return array
  *   The current Form State with manage_xacml element appended.
  */
-function islandora_xacml_editor_islandora_build_manage_object(array $form_state, AbstractObject $object) {
+function islandora_xacml_editor_islandora_basic_collection_build_manage_object(array $form_state, AbstractObject $object) {
   $form_state['manage_collection_object']['manage_xacml'] = array(
     '#id' => 'manage-xacml',
     '#group' => 'manage_xacml_object',
@@ -289,7 +303,6 @@ function islandora_xacml_editor_islandora_build_manage_object(array $form_state,
  *   The current Form State being processed.
  */
 function islandora_xacml_editor_form_islandora_basic_collection_create_child_collection_form_alter(array &$form, array &$form_state) {
-  dsm($form);
   $parent_object = islandora_object_load($form_state['islandora']['shared_storage']['parent']);
   $xacml_options = array('None' => 'none');
   if ($parent_object) {
@@ -297,7 +310,7 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
   }
 
   $form['xacml'] = array(
-    '#weight' => 1,
+    '#weight' => -1,
     '#type' => 'select',
     '#title' => t('Inherit XACML policy from'),
     '#options' => $xacml_options,
@@ -319,10 +332,14 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
  */
 function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_state, AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $child_collections_pids = islandora_basic_collection_get_child_pids($object, 'islandora:collectionCModel');
+  $dt = islandora_basic_collection_get_member_objects($object, 0, 20, 'view', 'islandora:collectionCModel');
+  $child_collections_pids = array();
   $rows = array();
   $options = array('none' => 'None');
-  $child_collection;
+  // Get the pids of the children for this collection.
+  foreach ($dt[1] as $info) {
+    array_push($child_collections_pids, $info['object']['value']);
+  }
   foreach ($child_collections_pids as $pid) {
     $child_collection = islandora_object_load($pid);
     $parent_pids = islandora_basic_collection_get_parent_pids($child_collection);
@@ -358,7 +375,10 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
       '#header' => array(
         array('class' => array('select-all')), t('COLLECTION(PID)'), 'INHERIT FROM',
       ),
-      '#theme' => 'islandora_basic_collection_policy_management_table',
+      'pager' => array(
+        '#markup' => theme('pager'),
+      ),
+      '#theme' => 'islandora_xacml_editor_policy_management_table',
       'rows' => $rows,
     ),
     'submit' => array(
@@ -377,7 +397,6 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
  *   The Drupal form state.
  */
 function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$form_state) {
-  $parent_object;
   $child_pids = array_keys($form_state['values']['table']['rows']);
   $count = 0;
   foreach ($form_state['values']['table']['rows'] as $row) {

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -5,7 +5,7 @@
  */
 
 // Permission.
-define('ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION', 'administer xacml inheritance');
+define('ISLANDORA_XACML_EDITOR_ADMINISTER_INHERITANCE_PERMISSION', 'administer xacml inheritance');
 
 /**
  * Implements hook_permission().
@@ -15,7 +15,7 @@ function islandora_xacml_editor_permission() {
     'administer islandora_xacml_editor' => array(
       'title' => 'Edit XACML Policies',
     ),
-    ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION => array(
+    ISLANDORA_XACML_EDITOR_ADMINISTER_INHERITANCE_PERMISSION => array(
       'title' => 'Edit XACML Inheritance',
     ),
   );
@@ -107,68 +107,6 @@ function islandora_xacml_editor_islandora_object_access($op, $object, $user) {
 }
 
 /**
- * Implements hook_islandora_datastream_purged().
- */
-function islandora_xacml_editor_islandora_datastream_purged(AbstractObject $object, $dsid) {
-  $viewable_by_user = 'isViewableByUser';
-  $viewable_by_role = 'isViewableByRole';
-  // The XACML POLICY is removed.
-  if ($dsid === 'POLICY') {
-    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_user);
-    $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_role);
-    foreach ($object as $dsid => $value) {
-      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
-      $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
-    }
-  }
-  else {
-    // An individual datastream is removed.
-    if (isset($object['POLICY'])) {
-      $xacml = new IslandoraXacml($object);
-      $ds_rule = $xacml->datastreamRule->getRuleArray();
-      if (array_search($dsid, $ds_rule['dsids']) !== FALSE) {
-        if (count($ds_rule['users']) > 0) {
-          $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
-        }
-        if (count($ds_rule['roles']) > 0) {
-          $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
-        }
-      }
-    }
-  }
-}
-
-/**
- * Implements hook_islandora_datastream_ingested().
- */
-function islandora_xacml_editor_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
-  if (isset($object['POLICY'])) {
-    $xacml = new IslandoraXacml($object);
-    $ds_rule = $xacml->datastreamRule->getRuleArray();
-    if (array_search($datastream->id, $ds_rule['dsids']) !== FALSE) {
-      $viewable_by_user = 'isViewableByUser';
-      $viewable_by_role = 'isViewableByRole';
-      if (count($ds_rule['users']) > 0) {
-        foreach ($ds_rule['users'] as $user) {
-          // The XACML API adds fedoraAdmin to the list of users as to prevent
-          // an object from being completely locked out. As this role is a
-          // Fedora role and has no interaction with Drupal we won't add it for
-          // cleanliness sake.
-          if ($user !== 'fedoraAdmin') {
-            $object[$datastream->id]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_user, $user, TRUE);
-          }
-        }
-      }
-      if (count($ds_rule['roles']) > 0) {
-        foreach ($ds_rule['roles'] as $role) {
-          $object[$datastream->id]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_role, $role, TRUE);
-        }
-      }
-    }
-  }
-}
-
-/**
  * Implemenets hook_islandora_xacml_editor_child_query().
  */
 function islandora_xacml_editor_islandora_collectionCModel_islandora_xacml_editor_child_query($object) {
@@ -243,7 +181,7 @@ function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
     }
   }
   if (!isset($parent_object['POLICY'])) {
-    drupal_set_message(t('Parent @object does not contain an xacml policy.'), array('@object' => $parent->id), 'status');
+    drupal_set_message(t('Parent @object does not contain an xacml policy.'), array('@object' => $parent), 'status');
   }
 }
 
@@ -291,7 +229,7 @@ function islandora_xacml_editor_islandora_basic_collection_build_manage_object(a
   $form_state['manage_collection_object']['manage_xacml'] = array(
     '#id' => 'manage-xacml',
     '#group' => 'manage_xacml_object',
-    '#access' => user_access(ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION),
+    '#access' => user_access(ISLANDORA_XACML_EDITOR_ADMINISTER_INHERITANCE_PERMISSION),
     '#type' => 'fieldset',
     '#title' => t('Manage XACML Inheritance'),
     'form' => drupal_get_form('islandora_xacml_editor_manage_xacml_form', $object),
@@ -445,23 +383,8 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
         // we must remove the current XACML policy if it exists.
         $object = islandora_object_load($child_pids[$count]);
         if (isset($object['POLICY'])) {
-          $viewable_by_user = 'isViewableByUser';
-          $viewable_by_role = 'isViewableByRole';
-          $manageable_by_user = 'isManageableByUser';
-          $manageable_by_role = 'isManageableByRole';
           $object->relationships->remove(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $object->purgeDatastream('POLICY');
-          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_user);
-          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_role);
-          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_user);
-          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_role);
-
-          foreach ($object as $dsid => $value) {
-            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
-            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
-            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_user);
-            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
-          }
           $message .= $object->id . " no longer inherits XACML from " . $parent_object->id . "\n";
         }
       }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -470,7 +470,6 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
         }
       }
     }
-    
     $count++;
   }
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -374,15 +374,15 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();
-          drupal_set_message(t('@parent does not have an XACML policy.',
+          drupal_set_message(t('@child now inherits XACML from @parent.',
             array(
+              '@child' => $object->id,
               '@parent' => $parent_object->id)),
             'status');
         }
         else {
-          drupal_set_message(t('@child now inherits XACML from @parent.',
+          drupal_set_message(t('@parent does not have an XACML policy.',
             array(
-              '@child' => $object->id,
               '@parent' => $parent_object->id)),
             'status');
         }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -310,11 +310,30 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
   }
 
   $form['xacml'] = array(
-    '#weight' => -1,
     '#type' => 'select',
     '#title' => t('Inherit XACML policy from'),
     '#options' => $xacml_options,
   );
+  // Using after_build to alter the weight dynamically.
+  $form['#after_build'][] = 'islandora_xacml_editor_after_build';
+}
+
+/**
+ * Dynamically adjust form element weights in after_build.
+ *
+ * @param array $form
+ *   The form that has been rendered.
+ * @param array $form_state
+ *   The active form's form state.
+ *
+ * @return array
+ *   The form after POST processing is complete.
+ */
+function islandora_xacml_editor_after_build($form, &$form_state) {
+  $form['xacml']['#weight'] = $form['next']['#weight'] - .001;
+  unset($form['#sorted']);
+  dsm($form);
+  return $form;
 }
 
 /**

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -237,7 +237,8 @@ function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
     }
   }
   if (!isset($parent_object['POLICY'])) {
-    drupal_set_message(t("Parent $parent does not contain an xacml policy."), 'status');
+    $tmp = check_plain($parent);
+    drupal_set_message(check_plain(t('Parent $tmp does not contain an xacml policy.'), 'status'));
   }
 }
 

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -237,7 +237,7 @@ function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
     }
   }
   if (!isset($parent_object['POLICY'])) {
-    drupal_set_message(check_plain(t('Parent $tmp does not contain an xacml policy.'), 'status'));
+    drupal_set_message(t('Parent @object does not contain an xacml policy.'), array('@object' => $parent->id), 'status');
   }
 }
 

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -237,7 +237,6 @@ function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
     }
   }
   if (!isset($parent_object['POLICY'])) {
-    $tmp = check_plain($parent);
     drupal_set_message(check_plain(t('Parent $tmp does not contain an xacml policy.'), 'status'));
   }
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -375,7 +375,12 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();
-          $message .= $object->id . " now inherits XACML from " . $parent_object->id . "\n";
+          drupal_set_message(t('@child now inherits XACML from @parent.',
+            array(
+              '@child' => $object->id,
+              '@parent' => $parent_object->id),
+            'status')
+          );
         }
       }
       else {
@@ -385,11 +390,13 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
         if (isset($object['POLICY'])) {
           $object->relationships->remove(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $object->purgeDatastream('POLICY');
-          $message .= $object->id . " no longer inherits XACML from " . $parent_object->id . "\n";
+          drupal_set_message(t('@child no longer inherits XACML.',
+            array('@object' => $object->id),
+            'status')
+          );
         }
       }
     }
     $count++;
   }
-  drupal_set_message(t('@message', array('@message' => $message), 'status'));
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -396,7 +396,7 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->remove(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $object->purgeDatastream('POLICY');
           drupal_set_message(t('@child no longer inherits XACML.',
-            array('@object' => $object->id)),
+            array('@child' => $object->id)),
             'status');
         }
       }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -430,6 +430,12 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();
+          drupal_set_message(t('@object now inherits XACML from @parent',
+            array(
+              '@object' => $object->id,
+              '@parent' => $parent_object->id),
+            'status')
+          );
         }
       }
       else {
@@ -454,9 +460,17 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
             $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_user);
             $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
           }
+          drupal_set_message(t('@object no longer inherits XACML from @parent',
+            array(
+              '@object' => $object->id,
+              '@parent' => $parent_object->id),
+              'status'
+            )
+          );
         }
       }
     }
+    
     $count++;
   }
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -216,8 +216,11 @@ function islandora_xacml_editor_islandora_ingest_steps(array $form_state) {
  */
 function islandora_xacml_editor_apply_policy(&$form_state, $parent) {
   $parent_object = islandora_object_load($parent);
-  if ($parent_object['POLICY']) {
+  if ($parent_object['POLICY'] && $form_state['input']['xacml'] != 'None') {
     foreach ($form_state['islandora']['objects'] as $object) {
+      // Need to update the RELS-INT to indicate which parent this policy is
+      // inherited from.
+      $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent, TRUE);
       $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
       $xacml->writeBackToFedora();
     }
@@ -250,5 +253,173 @@ function islandora_xacml_editor_undo_policy(&$form_state) {
         $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
       }
     }
+  }
+}
+
+/**
+ * Implements islandora_build_manage_object_hook().
+ *
+ * @param array $form_state
+ *   The current Form State being processed.
+ * @param AbstractObject $object
+ *   The Islandora Object being processed.
+ *
+ * @return array
+ *   The current Form State with manage_xacml element appended.
+ */
+function islandora_xacml_editor_islandora_build_manage_object(array $form_state, AbstractObject $object) {
+  $form_state['manage_collection_object']['manage_xacml'] = array(
+    '#id' => 'manage-xacml',
+    '#group' => 'manage_xacml_object',
+    '#access' => TRUE,
+    '#type' => 'fieldset',
+    '#title' => t('Manage XACML Inheritance'),
+    'form' => drupal_get_form('islandora_xacml_editor_manage_xacml_form', $object),
+  );
+  $form_state['manage_collection_object']['manage_xacml']['form']['#submit'][] = 'islandora_xacml_editor_manage_xacml_form_submit';
+  return $form_state;
+}
+
+/**
+ * Form alter the child collection form.
+ *
+ * @param array $form
+ *   The form being passed from the hook.
+ * @param array $form_state
+ *   The current Form State being processed.
+ */
+function islandora_xacml_editor_form_islandora_basic_collection_create_child_collection_form_alter(array &$form, array &$form_state) {
+  dsm($form);
+  $parent_object = islandora_object_load($form_state['islandora']['shared_storage']['parent']);
+  $xacml_options = array('None' => 'none');
+  if ($parent_object) {
+    $xacml_options[$parent_object->id] = $parent_object->label;
+  }
+
+  $form['xacml'] = array(
+    '#weight' => 1,
+    '#type' => 'select',
+    '#title' => t('Inherit XACML policy from'),
+    '#options' => $xacml_options,
+  );
+}
+
+/**
+ * Define the xacml management form.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ * @param AbstractObject $object
+ *   The collection to move child objects from.
+ *
+ * @return array
+ *   The Drupal form definition.
+ */
+function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_state, AbstractObject $object) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $child_collections_pids = islandora_basic_collection_get_child_pids($object, 'islandora:collectionCModel');
+  $rows = array();
+  $options = array('none' => 'None');
+  $child_collection;
+  foreach ($child_collections_pids as $pid) {
+    $child_collection = islandora_object_load($pid);
+    $parent_pids = islandora_basic_collection_get_parent_pids($child_collection);
+    $rels_ext = $child_collection->relationships->get(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom');
+    foreach ($parent_pids as $parent_pid) {
+      $parent_object = islandora_object_load($parent_pid);
+      $options[$parent_object->id] = $parent_object->label;
+    }
+    $default_value = (isset($rels_ext[0]) ? $rels_ext[0]['object']['value'] : 'none');
+    $rows[$pid] = array(
+      'selected' => array(
+        '#type' => 'checkbox',
+        '#default_value' => FALSE,
+      ),
+      'title' => array(
+        '#markup' => l(t('@label (@pid)', array('@label' => $child_collection->label, '@pid' => $pid)), "islandora/object/{$pid}"),
+      ),
+      'parents' => array(
+        '#type' => 'select',
+        '#options' => $options,
+        '#default_value' => $default_value,
+      ),
+    );
+  }
+  return array(
+    '#action' => request_uri() . '#policy-management',
+    'help' => array(
+      '#type' => 'item',
+      '#markup' => t('XACML Inheritance Policies'),
+    ),
+    'table' => array(
+      '#tree' => TRUE,
+      '#header' => array(
+        array('class' => array('select-all')), t('COLLECTION(PID)'), 'INHERIT FROM',
+      ),
+      '#theme' => 'islandora_basic_collection_policy_management_table',
+      'rows' => $rows,
+    ),
+    'submit' => array(
+      '#type' => 'submit',
+      '#value' => t('Update XACML Inheritance'),
+    ),
+  );
+}
+
+/**
+ * Submit handler for the manage XACML form.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$form_state) {
+  $parent_object;
+  $child_pids = array_keys($form_state['values']['table']['rows']);
+  $count = 0;
+  foreach ($form_state['values']['table']['rows'] as $row) {
+    // Check if selected.
+    if ($row['selected'] > 0) {
+      $parent_object = islandora_object_load($row['parents']);
+      // Are we adding the XACML POLICY or removing it? Just
+      // check for a valid fedora object.
+      if ($parent_object) {
+        // Make sure there is a POLICY to inherit.
+        if ($parent_object['POLICY']) {
+          $object = islandora_object_load($child_pids[$count]);
+          $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
+          $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
+          $xacml->writeBackToFedora();
+        }
+      }
+      else {
+        // 'None' is currently selected for this row, so if it is selected,
+        // we must remove the current XACML policy if it exists.
+        $object = islandora_object_load($child_pids[$count]);
+        if (isset($object['POLICY'])) {
+          $viewable_by_user = 'isViewableByUser';
+          $viewable_by_role = 'isViewableByRole';
+          $manageable_by_user = 'isManageableByUser';
+          $manageable_by_role = 'isManageableByRole';
+          $object->relationships->remove(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
+          $object->purgeDatastream('POLICY');
+          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_user);
+          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $viewable_by_role);
+          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_user);
+          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, $manageable_by_role);
+
+          foreach ($object as $dsid => $value) {
+            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_user);
+            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $viewable_by_role);
+            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_user);
+            $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
+          }
+        }
+      }
+    }
+    $count++;
   }
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -4,6 +4,9 @@
  * The main module file for the Islanora XACML Editor.
  */
 
+// Permission.
+define('ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION', 'administer xacml inheritance');
+
 /**
  * Implements hook_permission().
  */
@@ -11,6 +14,9 @@ function islandora_xacml_editor_permission() {
   return array(
     'administer islandora_xacml_editor' => array(
       'title' => 'Edit XACML Policies',
+    ),
+    ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION => array(
+      'title' => 'Edit XACML Inheritance',
     ),
   );
 }
@@ -36,7 +42,7 @@ function islandora_xacml_editor_menu() {
     'weight' => 0,
     'page callback' => 'drupal_get_form',
     'page arguments' => array('islandora_xacml_editor_form', 2),
-    'access callback' => 'islandora_xacml_editor_access',
+    'access callback' => array('administer islandora_xacml_editor'),
     'access arguments' => array(2),
     'file' => 'includes/form.inc',
   );
@@ -84,6 +90,9 @@ function islandora_xacml_editor_access($object) {
   return islandora_object_access('administer islandora_xacml_editor', $object);
 }
 
+function islandora_xacml_editor_manage_inheritance($object) {
+  return islandora_object_access(ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION, $object);
+}
 /**
  * Implements hook_islandora_object_access().
  */
@@ -285,12 +294,13 @@ function islandora_xacml_editor_islandora_basic_collection_build_manage_object(a
   $form_state['manage_collection_object']['manage_xacml'] = array(
     '#id' => 'manage-xacml',
     '#group' => 'manage_xacml_object',
-    '#access' => TRUE,
+    '#access' => user_access(ISLANDORA_XACML_ADMINISTER_INHERITANCE_PERMISSION),
     '#type' => 'fieldset',
     '#title' => t('Manage XACML Inheritance'),
     'form' => drupal_get_form('islandora_xacml_editor_manage_xacml_form', $object),
   );
   $form_state['manage_collection_object']['manage_xacml']['form']['#submit'][] = 'islandora_xacml_editor_manage_xacml_form_submit';
+
   return $form_state;
 }
 
@@ -417,6 +427,7 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
 function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$form_state) {
   $child_pids = array_keys($form_state['values']['table']['rows']);
   $count = 0;
+  $message = "Complete: " . "\n";
   foreach ($form_state['values']['table']['rows'] as $row) {
     // Check if selected.
     if ($row['selected'] > 0) {
@@ -430,12 +441,7 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();
-          drupal_set_message(t('@object now inherits XACML from @parent',
-            array(
-              '@object' => $object->id,
-              '@parent' => $parent_object->id),
-            'status')
-          );
+          $message .= $object->id . " now inherits XACML from " . $parent_object->id . "\n";
         }
       }
       else {
@@ -460,16 +466,11 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
             $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_user);
             $object[$dsid]->relationships->remove(ISLANDORA_RELS_INT_URI, $manageable_by_role);
           }
-          drupal_set_message(t('@object no longer inherits XACML from @parent',
-            array(
-              '@object' => $object->id,
-              '@parent' => $parent_object->id),
-              'status'
-            )
-          );
+          $message .= $object->id . " no longer inherits XACML from " . $parent_object->id . "\n";
         }
       }
     }
     $count++;
   }
+  drupal_set_message(t($message,'status'));
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -375,12 +375,17 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->add(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $xacml = new IslandoraXacml($object, $parent_object['POLICY']->content);
           $xacml->writeBackToFedora();
+          drupal_set_message(t('@parent does not have an XACML policy.',
+            array(
+              '@parent' => $parent_object->id)),
+            'status');
+        }
+        else {
           drupal_set_message(t('@child now inherits XACML from @parent.',
             array(
               '@child' => $object->id,
-              '@parent' => $parent_object->id),
-            'status')
-          );
+              '@parent' => $parent_object->id)),
+            'status');
         }
       }
       else {
@@ -391,9 +396,8 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
           $object->relationships->remove(FEDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object, TRUE);
           $object->purgeDatastream('POLICY');
           drupal_set_message(t('@child no longer inherits XACML.',
-            array('@object' => $object->id),
-            'status')
-          );
+            array('@object' => $object->id)),
+            'status');
         }
       }
     }


### PR DESCRIPTION
Allows for one to choose when to apply XACML policy's to a child collection and which parent to inherit from. This can be done pre/post ingest.
