### PR TITLE
Fix bug when adding viewing role after management.

### DIFF
--- a/api/islandora_xacml_api.rules.inc
+++ b/api/islandora_xacml_api.rules.inc
@@ -73,8 +73,13 @@ function islandora_xacml_api_rules_islandora_xacml_getter($data, array $options,
  * Getter helper for our islandora_xacml "Rule" type.
  */
 function islandora_xacml_api_rules_islandora_xacml_rule_getter($data, array $options, $name, $type, $info) {
-  $rule = $data->getRuleArray();
-  return $rule[$name];
+  if ($data->isPopulated()) {
+    $rule = $data->getRuleArray();
+    return $rule[$name];
+  }
+  else {
+    return array();
+  }
 }
 
 /**


### PR DESCRIPTION
"Viewing" returns using with management and datastream permissions
when listing users and roles, even though the rule wasn't populated...
therefore, trying to "ensure uniqueness" was causing it to break.
