### PR TITLE
Fix issue with writing relationships.

### DIFF
--- a/api/includes/islandora_xacml.inc
+++ b/api/includes/islandora_xacml.inc
@@ -88,26 +88,28 @@ class IslandoraXacml extends Xacml {
 
     // Add Object Viewing Relationships.
     if ($this->viewingRule->isPopulated()) {
+      $view_data = $this->viewingRule->getRuleArray();
       // Recompute the new values from the policy.
-      foreach ($this->viewingRule->getUsers() as $user) {
+      foreach ($view_data['users'] as $user) {
         $this->object->relationships->add(ISLANDORA_RELS_EXT_URI, $viewable_by_user, $user, TRUE);
       }
 
-      foreach ($this->viewingRule->getRoles() as $role) {
+      foreach ($view_data['roles'] as $role) {
         $this->object->relationships->add(ISLANDORA_RELS_EXT_URI, $viewable_by_role, $role, TRUE);
       }
     }
 
     // Add Datastream Viewing Relationships.
     if ($this->datastreamRule->isPopulated()) {
-      foreach ($this->datastreamRule->getDsids() as $dsid) {
+      $datastream_data = $this->datastreamRule->getRuleArray();
+      foreach ($datastream_data['dsids'] as $dsid) {
         // Recompute the new values from the policy.
-        foreach ($this->datastreamRule->getUsers() as $user) {
+        foreach ($datastream_data['users'] as $user) {
           if (isset($this->object[$dsid])) {
             $this->object[$dsid]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_user, $user, TRUE);
           }
         }
-        foreach ($this->datastreamRule->getRoles() as $role) {
+        foreach ($datastream_data['roles'] as $role) {
           if (isset($this->object[$dsid])) {
             $this->object[$dsid]->relationships->add(ISLANDORA_RELS_INT_URI, $viewable_by_role, $role, TRUE);
           }
@@ -117,11 +119,12 @@ class IslandoraXacml extends Xacml {
 
     // Add Object Management Relationships.
     if ($this->managementRule->isPopulated()) {
+      $management_data = $this->managementRule->getRuleArray();
       // Recompute the new values from the policy.
-      foreach ($this->managementRule->getUsers() as $user) {
+      foreach ($management_data['users'] as $user) {
         $this->object->relationships->add(ISLANDORA_RELS_EXT_URI, $manageable_by_user, $user, TRUE);
       }
-      foreach ($this->managementRule->getRoles() as $role) {
+      foreach ($management_data['roles'] as $role) {
         $this->object->relationships->add(ISLANDORA_RELS_EXT_URI, $manageable_by_role, $role, TRUE);
       }
     }

--- a/api/islandora_xacml_api.info
+++ b/api/islandora_xacml_api.info
@@ -11,5 +11,6 @@ files[] = includes/exception.inc
 files[] = includes/parser.inc
 files[] = includes/writer.inc
 files[] = tests/api.test
+files[] = tests/rels.test
 files[] = tests/hooked_access.test
 testing_api = 2.x

--- a/api/tests/rels.test
+++ b/api/tests/rels.test
@@ -76,7 +76,7 @@ class IslandoraXacmlApiRelsWritingTest extends IslandoraWebTestCase {
     $this->assertFalse($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByUser', 'asdfer', RELS_TYPE_PLAIN_LITERAL), 'Management relationship does not exist for datastream access user.');
   }
 
-  /** 
+  /**
    * Test if writing "roles" first affects the ability of writing "users".
    */
   public function testRoleUserRels() {
@@ -85,7 +85,7 @@ class IslandoraXacmlApiRelsWritingTest extends IslandoraWebTestCase {
     $this->testRoleRels();
   }
 
-  /** 
+  /**
    * Test if writing "users" first affects the ability of writing "roles".
    */
   public function testUserRoleRels() {

--- a/api/tests/rels.test
+++ b/api/tests/rels.test
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @file
+ * Test relationship writing in XACML.
+ */
+
+class IslandoraXacmlApiRelsWritingTest extends IslandoraWebTestCase {
+  /**
+   * Inherits.
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Islandora XACML API Relationships',
+      'description' => 'Ensure that relationships are written appropriately.',
+      'group' => 'Islandora XACML Editor',
+    );
+  }
+
+  /**
+   * Inherits.
+   */
+  public function setUp() {
+    parent::setUp('islandora_xacml_api');
+
+    // Our setup... Create the object.
+    variable_set('islandora_xacml_api_save_relationships', TRUE);
+    $this->repository = islandora_get_tuque_connection()->repository;
+    $this->object = $this->repository->constructObject('no:ingest');
+    $this->datastream = $this->object->constructDatastream('THE_DATA', 'M');
+    $this->datastream->label = 'label';
+    $this->datastream->mimetype = 'text/plain';
+    $this->datastream->content = 'le content';
+    $this->object->ingestDatastream($this->datastream);
+  }
+
+  /**
+   * Test writing of "role" relationships.
+   */
+  public function testRoleRels() {
+    $xacml = new IslandoraXacml($this->object);
+    $xacml->viewingRule->addRole('viewers');
+    $xacml->managementRule->addRole('managers');
+    $xacml->datastreamRule->addDsid($this->datastream->id);
+    $xacml->datastreamRule->addRole('asdfers');
+    $xacml->writeBackToFedora();
+
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByRole', 'viewers', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists for added viewing role.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByRole', 'managers', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists for add managment role.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByRole', 'asdfers', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists on object for datastream access role.');
+    $this->assertTrue($this->datastream->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByRole', 'asdfers', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists on datastream for datastream access role.');
+
+    $this->assertFalse($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByRole', 'viewers', RELS_TYPE_PLAIN_LITERAL), 'Management relationship does not exist for added viewing role.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByRole', 'managers', RELS_TYPE_PLAIN_LITERAL), 'Management relationship exists for managment role.');
+    $this->assertFalse($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByRole', 'asdfers', RELS_TYPE_PLAIN_LITERAL), 'Management relationship does not exist for datastream access role.');
+  }
+
+  /**
+   * Test writing of "user" relationships.
+   */
+  public function testUserRels() {
+    $xacml = new IslandoraXacml($this->object);
+    $xacml->viewingRule->addUser('viewer');
+    $xacml->managementRule->addUser('manager');
+    $xacml->datastreamRule->addDsid($this->datastream->id);
+    $xacml->datastreamRule->addUser('asdfer');
+    $xacml->writeBackToFedora();
+
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByUser', 'viewer', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists for added viewing user.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByUser', 'manager', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists for add managment user.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isViewableByUser', 'asdfer', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists on object for datastream access user.');
+    $this->assertTrue($this->datastream->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByUser', 'asdfer', RELS_TYPE_PLAIN_LITERAL), 'Viewing relationship exists on datastream for datastream access user.');
+
+    $this->assertFalse($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByUser', 'viewer', RELS_TYPE_PLAIN_LITERAL), 'Management relationship does not exist for added viewing user.');
+    $this->assertTrue($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByUser', 'manager', RELS_TYPE_PLAIN_LITERAL), 'Management relationship exists for managment user.');
+    $this->assertFalse($this->object->relationships->get(ISLANDORA_RELS_EXT_URI, 'isManageableByUser', 'asdfer', RELS_TYPE_PLAIN_LITERAL), 'Management relationship does not exist for datastream access user.');
+  }
+
+  /** 
+   * Test if writing "roles" first affects the ability of writing "users".
+   */
+  public function testRoleUserRels() {
+    $this->testRoleRels();
+    $this->testUserRels();
+    $this->testRoleRels();
+  }
+
+  /** 
+   * Test if writing "users" first affects the ability of writing "roles".
+   */
+  public function testUserRoleRels() {
+    $this->testUserRels();
+    $this->testRoleRels();
+    $this->testUserRels();
+  }
+}


### PR DESCRIPTION
Relationships could be out of sync due to how we were obtaining the
lists of users and roles.

Solr/RI displays may attempt to show objects which should be hidden,
but XACML would still block access.
