### PR TITLE
Make pager unique, submit bug.

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -295,8 +295,8 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
   // Hard code the XACML pager element because it needs to be unique.
   $pager_element = 3;
   $page = pager_find_page($pager_element);
-  list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, 20, 'manage');
-  pager_default_initialize($count, 20, $pager_element);
+  list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, 10, 'manage');
+  pager_default_initialize($count, 10, $pager_element);
   $rows = array();
   $options = array('none' => 'None');
   // Get the pids of the children for this collection.

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -291,67 +291,70 @@ function islandora_xacml_editor_after_build($form, &$form_state) {
  *   The Drupal form definition.
  */
 function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_state, AbstractObject $object) {
-  module_load_include('inc', 'islandora', 'includes/utilities');
-  // Hard code the XACML pager element because it needs to be unique.
-  $pager_element = 3;
-  $page = pager_find_page($pager_element);
-  list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, 10, 'manage');
-  pager_default_initialize($count, 10, $pager_element);
-  $rows = array();
-  $options = array('none' => 'None');
-  // Get the pids of the children for this collection.
-  foreach ($results as $result) {
-    $pid = $result['object']['value'];
-    $child_collection = islandora_object_load($pid);
-    $parent_pids = islandora_basic_collection_get_parent_pids($child_collection);
-    $rels_ext = $child_collection->relationships->get(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom');
-    foreach ($parent_pids as $parent_pid) {
-      $parent_object = islandora_object_load($parent_pid);
-      $options[$parent_object->id] = $parent_object->label;
+  if (module_exists('islandora_basic_collection')) {
+    module_load_include('inc', 'islandora', 'includes/utilities');
+    // Hard code the XACML pager element because it needs to be unique.
+    $pager_element = 3;
+    $page = pager_find_page($pager_element);
+    list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, 10, 'manage', 'islandora:collectionCModel');
+    pager_default_initialize($count, 10, $pager_element);
+    $rows = array();
+    $options = array('none' => 'None');
+    // Get the pids of the children for this collection.
+    foreach ($results as $result) {
+      $pid = $result['object']['value'];
+      $child_collection = islandora_object_load($pid);
+      $parent_pids = islandora_basic_collection_get_parent_pids($child_collection);
+      $rels_ext = $child_collection->relationships->get(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom');
+      foreach ($parent_pids as $parent_pid) {
+        $parent_object = islandora_object_load($parent_pid);
+        $options[$parent_object->id] = $parent_object->label;
+      }
+      $default_value = (isset($rels_ext[0]) ? $rels_ext[0]['object']['value'] : 'none');
+      $rows[$pid] = array(
+        'selected' => array(
+          '#type' => 'checkbox',
+          '#default_value' => FALSE,
+        ),
+        'title' => array(
+          '#markup' => l(t('@label (@pid)', array('@label' => $child_collection->label, '@pid' => $pid)), "islandora/object/{$pid}"),
+        ),
+        'parents' => array(
+          '#type' => 'select',
+          '#options' => $options,
+          '#default_value' => $default_value,
+        ),
+      );
     }
-    $default_value = (isset($rels_ext[0]) ? $rels_ext[0]['object']['value'] : 'none');
-    $rows[$pid] = array(
-      'selected' => array(
-        '#type' => 'checkbox',
-        '#default_value' => FALSE,
+    // Theme pager doesn't support url fragments in D7 so we insert manually.
+    $pager = theme('pager', array('quantity' => 20, 'element' => $pager_element));
+    $pager = islandora_basic_collection_append_fragment_to_pager_url($pager, '#manage-xacml');
+    return array(
+      '#action' => request_uri() . '#manage-xacml',
+      'help' => array(
+        '#type' => 'item',
+        '#markup' => t('XACML Inheritance Policies'),
       ),
-      'title' => array(
-        '#markup' => l(t('@label (@pid)', array('@label' => $child_collection->label, '@pid' => $pid)), "islandora/object/{$pid}"),
+      'table' => array(
+        '#tree' => TRUE,
+        '#header' => array(
+          array('class' => array('select-all')), t('COLLECTION(PID)'), 'INHERIT FROM',
+        ),
+        '#theme' => 'islandora_xacml_editor_policy_management_table',
+        'rows' => $rows,
+        '#prefix' => $pager,
+        '#suffix' => $pager,
       ),
-      'parents' => array(
-        '#type' => 'select',
-        '#options' => $options,
-        '#default_value' => $default_value,
+      'submit' => array(
+        '#type' => 'submit',
+        '#value' => t('Update XACML Inheritance'),
+        '#access' => count($rows),
       ),
     );
   }
-  // Theme pager doesn't support url fragments in D7 so we insert manually.
-  $pager = theme('pager', array('quantity' => 20, 'element' => $pager_element));
-  $pattern = '/href="([^"]+)"/';
-  $replace = 'href="\1#manage-xacml"';
-  $pager = preg_replace($pattern, $replace, $pager);
-  return array(
-    '#action' => request_uri() . '#manage-xacml',
-    'help' => array(
-      '#type' => 'item',
-      '#markup' => t('XACML Inheritance Policies'),
-    ),
-    'table' => array(
-      '#tree' => TRUE,
-      '#header' => array(
-        array('class' => array('select-all')), t('COLLECTION(PID)'), 'INHERIT FROM',
-      ),
-      '#theme' => 'islandora_xacml_editor_policy_management_table',
-      'rows' => $rows,
-      '#prefix' => $pager,
-      '#suffix' => $pager,
-    ),
-    'submit' => array(
-      '#type' => 'submit',
-      '#value' => t('Update XACML Inheritance'),
-      '#access' => count($rows),
-    ),
-  );
+  else {
+    return array();
+  }
 }
 
 /**

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -292,15 +292,16 @@ function islandora_xacml_editor_after_build($form, &$form_state) {
  */
 function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_state, AbstractObject $object) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $dt = islandora_basic_collection_get_member_objects($object, 0, 20, 'view', 'islandora:collectionCModel');
-  $child_collections_pids = array();
+  // Hard code the XACML pager element because it needs to be unique.
+  $pager_element = 3;
+  $page = pager_find_page($pager_element);
+  list($count, $results) = islandora_basic_collection_get_member_objects($object, $page, 20, 'manage');
+  pager_default_initialize($count, 20, $pager_element);
   $rows = array();
   $options = array('none' => 'None');
   // Get the pids of the children for this collection.
-  foreach ($dt[1] as $info) {
-    array_push($child_collections_pids, $info['object']['value']);
-  }
-  foreach ($child_collections_pids as $pid) {
+  foreach ($results as $result) {
+    $pid = $result['object']['value'];
     $child_collection = islandora_object_load($pid);
     $parent_pids = islandora_basic_collection_get_parent_pids($child_collection);
     $rels_ext = $child_collection->relationships->get(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom');
@@ -324,8 +325,13 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
       ),
     );
   }
+  // Theme pager doesn't support url fragments in D7 so we insert manually.
+  $pager = theme('pager', array('quantity' => 20, 'element' => $pager_element));
+  $pattern = '/href="([^"]+)"/';
+  $replace = 'href="\1#manage-xacml"';
+  $pager = preg_replace($pattern, $replace, $pager);
   return array(
-    '#action' => request_uri() . '#policy-management',
+    '#action' => request_uri() . '#manage-xacml',
     'help' => array(
       '#type' => 'item',
       '#markup' => t('XACML Inheritance Policies'),
@@ -335,11 +341,10 @@ function islandora_xacml_editor_manage_xacml_form(array $form, array &$form_stat
       '#header' => array(
         array('class' => array('select-all')), t('COLLECTION(PID)'), 'INHERIT FROM',
       ),
-      'pager' => array(
-        '#markup' => theme('pager'),
-      ),
       '#theme' => 'islandora_xacml_editor_policy_management_table',
       'rows' => $rows,
+      '#prefix' => $pager,
+      '#suffix' => $pager,
     ),
     'submit' => array(
       '#type' => 'submit',
@@ -387,7 +392,7 @@ function islandora_xacml_editor_manage_xacml_form_submit(array $form, array &$fo
         // we must remove the current XACML policy if it exists.
         $object = islandora_object_load($child_pids[$count]);
         if (isset($object['POLICY'])) {
-          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom', $parent_object->id, RELS_TYPE_URI);
+          $object->relationships->remove(ISLANDORA_RELS_EXT_URI, 'inheritXacmlFrom');
           $object->purgeDatastream('POLICY');
           drupal_set_message(t('@child no longer inherits XACML.', array('@child' => $object->id)), 'status');
         }


### PR DESCRIPTION
**JIRA:** https://jira.duraspace.org/browse/ISLANDORA-1515
# What does this Pull Request do?

Fixes a bug where the "Manage XACML Inheritance" tab on a collection object does not render correctly. 

Enscapulated within:
- Pager is never rendered, and not rendered correctly.
- A byproduct of this is that the attempted to be rendered XACML pager uses the identifier of the first pager that's rendered in the vertical tabs. Currently, these tabs are permissionable and it's possible that no tabs with pagers will be rendered. When this case arises warnings throw as noted in the external JIRA ticket.
- The vertical tab re-uses the fragment identifier of the "Manage collection policy" tab which causes the focus to not retain on submit.
- Lastly, the removing of relationships does not need to include the parent PID and as such can cause a warning when changing an existing inheritance to "None".

Further details in the external JIRA ticket.
# How should this be tested?

Go to the "Manage XACML Inheritance" tab at yoursite/islandora/object/somecollectionobject/collection.
Note that there is no pager rendered and the fragment identifier is not correct when submitting. I.e. the tab does not retain the right focus when submitting the form.

**Tagging:** 
@mjordan: Would it be possible to look at this as I am the maintainer/reporter of this?

---

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
