### PR TITLE
ISLANDORA-1753 maintain user selection on 'child collection form' for…

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -246,7 +246,13 @@ function islandora_xacml_editor_islandora_basic_collection_build_manage_object(a
  */
 function islandora_xacml_editor_form_islandora_basic_collection_create_child_collection_form_alter(array &$form, array &$form_state) {
   $parent_object = islandora_object_load($form_state['islandora']['shared_storage']['parent']);
+
   $xacml_options = array('None' => 'None');
+
+  // If the form has a step_storage value set for this field, use it.
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'islandora_basic_collection');
+  $xacml_selected_option = isset($step_storage['values']['xacml']) ? array($step_storage['values']['xacml'] => $step_storage['values']['xacml']) : array('None' => 'None');
+
   if ($parent_object) {
     $xacml_options[$parent_object->id] = $parent_object->label;
   }
@@ -255,6 +261,7 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
     '#type' => 'select',
     '#title' => t('Inherit XACML policy from'),
     '#options' => $xacml_options,
+    '#default_value' => $xacml_selected_option,
   );
   // Using after_build to alter the weight dynamically.
   $form['#after_build'][] = 'islandora_xacml_editor_after_build';


### PR DESCRIPTION
**JIRA Ticket**:  [ISLANDORA-1753](https://jira.duraspace.org/browse/ISLANDORA-1753)

**related PULL REQUEST**: [#177 ISLANDORA-1753 - bad collection policy ](https://github.com/Islandora/islandora_solution_pack_collection/pull/177)
# What does this Pull Request do?

This module adds an 'Inherit XACML policy from' form element to the islandora_solution_pack_collection create_child_collection form - this pull request allows the user selected value to be maintained, in the case of a multi-step form.
# How should this be tested?
- Begin a Collection object ingest.
- Adjust 'Inherit XACML policy from' selection.
- Go forward to the next step.
- Go back, see that your selection was maintained.
- Go back again (in the case where more than one content model is available).
- Go forward, see that the 'Inherit XACML policy from' has been reset to the default value.
# Interested parties

@jordandukart - current maintainer for this module.
@willtp87 - current maintainer for the related pull request module -[islandora_solution_pack_collection](https://github.com/Islandora/islandora_solution_pack_collection)

---

Maureen Adams
_Developer_
**[discoverygarden inc.](http://discoverygarden.ca) | Managing Digital Content**
