### PR TITLE
ISLANDORA-1991 - Improved validation on updating policies

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -106,7 +106,7 @@ class IslandoraUpdatePolicy {
     if (isset($this->object)) {
       try {
         $xacml = new IslandoraXacml($this->object);
-        if (($xacml->managementRule->hasPermission($user->name, $user->roles) && isset($this->object['POLICY'])) || !isset($this->object['POLICY'])) {
+        if (!isset($this->object['POLICY']) || !$xacml->managementRule->isPopulated() || $xacml->managementRule->hasPermission($user->name, $user->roles)) {
           $success = $this->addOrUpdateAllPolicies();
         }
       }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1991

# What does this Pull Request do?

As seen [here](https://github.com/Islandora/islandora_xacml_editor/blob/7.x/includes/batch.inc#L109), when updating a policy there's no check to see if the managementRule is populated before checking to see if the user can access it. The solution here would be to restructure the conditions and check to see if the managementRule hasn't been populated.

Additionally: I changed the order of conditions to see if the POLICY datastream is set to the beginning to cut down on the lengthy if statement.

# How should this be tested?

- Create a test role and supply the role with permissions to use the XACML editor.
- Find a collection with at least one child object. Ensure there are no existing POLICY datastreams on the child or the collection and create a new policy and select the `All children of this collection and collections within this collection (existing and new)` option. This will create & apply the policies to the collection object and the child.
- Remove the policies from the child using the XACML editor UI (Do not remove the datastream).
- Return to the collection object and try to re-apply the policy using the `All children of this collection and collections within this collection (existing and new)`. This should fail to apply the policy to the child.

# Interested parties
@Islandora/7-x-1-x-committers
