### PR TITLE
Fix ordering of elements for PHP7 since sort order can be differnet.

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -263,6 +263,7 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
     '#options' => $xacml_options,
     '#default_value' => $xacml_selected_option,
   );
+
   // Using after_build to alter the weight dynamically.
   $form['#after_build'][] = 'islandora_xacml_editor_after_build';
 }
@@ -279,7 +280,11 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
  *   The form after POST processing is complete.
  */
 function islandora_xacml_editor_after_build($form, &$form_state) {
-  $form['xacml']['#weight'] = $form['next']['#weight'] - .001;
+  $weight =  $form['next']['#weight'] - .001;
+  if (isset($form['prev'])) {
+    $weight =  min($weight, $form['prev']['#weight'] - .001);
+  }
+  $form['xacml']['#weight'] = $weight;
   unset($form['#sorted']);
   return $form;
 }

--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -280,9 +280,9 @@ function islandora_xacml_editor_form_islandora_basic_collection_create_child_col
  *   The form after POST processing is complete.
  */
 function islandora_xacml_editor_after_build($form, &$form_state) {
-  $weight =  $form['next']['#weight'] - .001;
+  $weight = $form['next']['#weight'] - .001;
   if (isset($form['prev'])) {
-    $weight =  min($weight, $form['prev']['#weight'] - .001);
+    $weight = min($weight, $form['prev']['#weight'] - .001);
   }
   $form['xacml']['#weight'] = $weight;
   unset($form['#sorted']);


### PR DESCRIPTION
## JIRA Ticket
https://jira.duraspace.org/browse/ISLANDORA-2019

## What does this Pull Request do?

Makes sure that the XACML form modify appears just above the previous and next buttons.

## What's new?

Because the sort order of elements with the same weight can be different in PHP7 vs PHP5 the XACML selector on the collection ingest is appearing in the wrong place on PHP7 installs. See screenshot below. This should ensure its in the right place for PHP5 and PHP7.

![screen shot 2017-07-13 at 10 58 45 am](https://user-images.githubusercontent.com/569437/28171184-fe6d6f34-67bd-11e7-8b17-023cf9ee77cb.png)

# How should this be tested?

- Test with PHP7 that the buttons appear out of order
  - apply patch, make sure they appear in order
- Test with PHP5 that before and after the elements appear ordered correctly

# Interested parties
@Islandora/7-x-1-x-committers @jordandukart 