### PR TITLE
Add update Drush command to fix RELS-INT inconsistencies

### DIFF
--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -209,7 +209,7 @@ WHERE {
   }
   !filter
 }
-ORDER BY ?created
+ORDER BY ?created ?pid
 
 EOQ;
   if (!isset($sandbox['total'])) {

--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -234,7 +234,7 @@ EOQ;
     $limited_query = format_string($query, array(
       '!filter' => isset($filter) ? $filter : '',
     )) . <<<EOQ
-LIMIT 100
+LIMIT $limit
 EOQ;
 
     drush_log(dt('Querying for 100 objects.'));

--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -19,7 +19,7 @@ function islandora_xacml_api_drush_command() {
         'description' => dt('The max number of objects for which to query at a time. (affects memory usage, defaults to 100)'),
       ),
     ),
-    'drupal dependenies' => array(
+    'drupal dependencies' => array(
       'islandora',
       'islandora_xacml_api',
     ),
@@ -38,11 +38,11 @@ function islandora_xacml_api_drush_command() {
         'description' => dt('The max number of objects for which to query at a time. (affects memory usage, defaults to 100)'),
       ),
       'commit' => array(
-        'description' => dt('Whether to commit the update of POLICY datastreams. Defaults to FALSE.'),
+        'description' => dt('Whether to commit the changes to the relations of the POLICY. Defaults to FALSE.'),
         'required' => FALSE,
       ),
     ),
-    'drupal dependenies' => array(
+    'drupal dependencies' => array(
       'islandora',
       'islandora_xacml_api',
     ),
@@ -130,7 +130,7 @@ EOQ;
       $context['finished'] = 1;
 
       $context['message'] = t('Updated @count PID(s) and ran out of items early... Somebody manually updated a document?', array(
-        '@count' => $sandbox['total'],
+        '@count' => $sandbox['progress'],
       ));
       return;
     }
@@ -242,7 +242,7 @@ EOQ;
     if (empty($sandbox['result_stash'])) {
       $context['finished'] = 1;
       $context['message'] = t('Updated @count PID(s) and ran out of items early. POLICY was manually removed?', array(
-        '@count' => $sandbox['total'],
+        '@count' => $sandbox['progress'],
       ));
       return;
     }
@@ -268,14 +268,14 @@ EOQ;
         $user_rels = $object[$dsid]->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByUser', $user, RELS_TYPE_PLAIN_LITERAL);
         if (!$user_rels) {
           $to_update = TRUE;
-          break;
+          break 2;
         }
       }
       foreach ($datastream_data['roles'] as $role) {
         $role_rels = $object[$dsid]->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByRole', $role, RELS_TYPE_PLAIN_LITERAL);
         if (!$role_rels) {
           $to_update = TRUE;
-          break;
+          break 2;
         }
       }
     }

--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -293,7 +293,7 @@ EOQ;
   }
   $sandbox['progress'] = min($sandbox['total'], $sandbox['progress'] + 1);
   $context['finished'] = $sandbox['progress'] / $sandbox['total'];
-  $context['message'] = t('Updated @progress of @total.', array(
+  $context['message'] = t('Checked @progress of @total.', array(
     '@progress' => $sandbox['progress'],
     '@total' => $sandbox['total'],
   ));

--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -27,7 +27,29 @@ function islandora_xacml_api_drush_command() {
       'drush -u 1 islandora-xacml-api-relationships-update-batch',
     ),
   );
-
+  $command['islandora-xacml-api-relationships-missing-rels-int-batch'] = array(
+    'bootstrap' => DRUSH_BOOTSTRAP_MAX,
+    'aliases' => array(
+      'ixarmrib',
+    ),
+    'options' => array(
+      'limit' => array(
+        'value' => 'optional',
+        'description' => dt('The max number of objects for which to query at a time. (affects memory usage, defaults to 100)'),
+      ),
+      'commit' => array(
+        'description' => dt('Whether to commit the update of POLICY datastreams. Defaults to FALSE.'),
+        'required' => FALSE,
+      ),
+    ),
+    'drupal dependenies' => array(
+      'islandora',
+      'islandora_xacml_api',
+    ),
+    'examples' => array(
+      'drush -u 1 -v islandora-xacml-api-relationships-missing-rels-int-batch',
+    ),
+  );
   return $command;
 }
 
@@ -130,6 +152,147 @@ EOQ;
   $sandbox['progress'] = min($sandbox['total'], $sandbox['progress'] + 1);
   $context['finished'] = $sandbox['progress'] / $sandbox['total'];
 
+  $context['message'] = t('Updated @progress of @total.', array(
+    '@progress' => $sandbox['progress'],
+    '@total' => $sandbox['total'],
+  ));
+}
+
+/**
+ * Drush command callback for RELS-INT inconsistencies batch.
+ */
+function drush_islandora_xacml_api_relationships_missing_rels_int_batch() {
+  $batch = array(
+    'operations' => array(
+      array(
+        'islandora_xacml_api_relationships_missing_rels_int_update_batch_operation',
+        array(
+          drush_get_option('limit', 100),
+          drush_get_option('commit', FALSE),
+        ),
+      ),
+    ),
+  );
+
+  batch_set($batch);
+
+  drush_backend_batch_process();
+}
+
+/**
+ * Batch operation; identify and update a PID.
+ */
+function islandora_xacml_api_relationships_missing_rels_int_update_batch_operation($limit, $commit, &$context) {
+  if (!variable_get('islandora_xacml_api_save_relationships', TRUE)) {
+    drush_log(t('Relationships are disabled, nothing to do.'));
+  }
+  $sandbox =& $context['sandbox'];
+
+  // XXX: Can occasionally get be initialized as a different user...
+  drupal_static_reset('islandora_get_tuque_connection');
+  $tuque = islandora_get_tuque_connection();
+
+  $query = <<<EOQ
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT DISTINCT ?object ?created FROM <#ri>
+WHERE {
+  ?object <fedora-view:disseminates> ?ds ;
+          <fedora-view:disseminates> ?ds2 ;
+          <fedora-model:createdDate> ?created .
+  ?ds <fedora-view:disseminationType> <info:fedora/*/POLICY> .
+  {
+    ?ds2 <http://islandora.ca/ontology/relsint#isViewableByRole> "administrator"
+  }
+  UNION
+  {
+    ?ds2 <http://islandora.ca/ontology/relsint#isViewableByUser> "fedoraAdmin"
+  }
+  !filter
+}
+ORDER BY ?created
+
+EOQ;
+  if (!isset($sandbox['total'])) {
+    $sandbox['progress'] = 0;
+    $sandbox['total'] = $tuque->repository->ri->countQuery(format_string($query, array(
+      '!filter' => '',
+    )), 'sparql');
+    if ($sandbox['total'] == 0) {
+      $context['finished'] = 1;
+      $context['message'] = t('Nothing to verify.');
+      return;
+    }
+    $sandbox['result_stash'] = array();
+  }
+  if (empty($sandbox['result_stash'])) {
+    if (isset($sandbox['last_date'])) {
+      $filter = format_string('FILTER(?created > "!created"^^xsd:dateTime || (?created = "!created"^^xsd:dateTime && xsd:string(?object) > "info:fedora/!pid"^^xsd:string))', array(
+        '!created' => $sandbox['last_date'],
+        '!pid' => $sandbox['last_pid'],
+      ));
+    }
+    $limited_query = format_string($query, array(
+      '!filter' => isset($filter) ? $filter : '',
+    )) . <<<EOQ
+LIMIT 100
+EOQ;
+
+    drush_log(dt('Querying for 100 objects.'));
+    $sandbox['result_stash'] = $tuque->repository->ri->sparqlQuery($limited_query);
+    if (empty($sandbox['result_stash'])) {
+      $context['finished'] = 1;
+      $context['message'] = t('Updated @count PID(s) and ran out of items early. POLICY was manually removed?', array(
+        '@count' => $sandbox['total'],
+      ));
+      return;
+    }
+  }
+
+  $result = array_shift($sandbox['result_stash']);
+  $sandbox['last_date'] = $result['created']['value'];
+  $sandbox['last_pid'] = $result['object']['value'];
+  $object = islandora_object_load($result['object']['value']);
+  drush_log(dt('Processing @pid.', array(
+    '@pid' => $object->id,
+  )));
+  // Get the POLICY and compare it to the RELS-INT statements.
+  $xacml = new IslandoraXacml($object);
+  $to_update = FALSE;
+  $datastream_data = $xacml->datastreamRule->getRuleArray();
+  foreach ($datastream_data['dsids'] as $dsid) {
+    // Only check DSIDs that exist on the object given the nature of how the API
+    // writes RELS-INT statements when that datastream gets ingested.
+    if (isset($object[$dsid])) {
+      // Ensure the users and roles match up.
+      foreach ($datastream_data['users'] as $user) {
+        $user_rels = $object[$dsid]->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByUser', $user, RELS_TYPE_PLAIN_LITERAL);
+        if (!$user_rels) {
+          $to_update = TRUE;
+          break;
+        }
+      }
+      foreach ($datastream_data['roles'] as $role) {
+        $role_rels = $object[$dsid]->relationships->get(ISLANDORA_RELS_INT_URI, 'isViewableByRole', $role, RELS_TYPE_PLAIN_LITERAL);
+        if (!$role_rels) {
+          $to_update = TRUE;
+          break;
+        }
+      }
+    }
+  }
+  if ($to_update) {
+    drush_log(dt('The POLICY for @pid is missing RELS-INT statements.', array(
+      '@pid' => $object->id,
+    )));
+    if ($commit) {
+      drush_log(dt('Updating the RELS-INT statements for @pid.', array(
+        '@pid' => $object->id,
+      )));
+      $xacml->writeBackToFedora();
+    }
+  }
+  $sandbox['progress'] = min($sandbox['total'], $sandbox['progress'] + 1);
+  $context['finished'] = $sandbox['progress'] / $sandbox['total'];
   $context['message'] = t('Updated @progress of @total.', array(
     '@progress' => $sandbox['progress'],
     '@total' => $sandbox['total'],

--- a/api/islandora_xacml_api.drush.inc
+++ b/api/islandora_xacml_api.drush.inc
@@ -237,7 +237,7 @@ EOQ;
 LIMIT $limit
 EOQ;
 
-    drush_log(dt('Querying for 100 objects.'));
+    drush_log(dt('Querying for @count objects.', array('@count' => $limit)));
     $sandbox['result_stash'] = $tuque->repository->ri->sparqlQuery($limited_query);
     if (empty($sandbox['result_stash'])) {
       $context['finished'] = 1;

--- a/api/islandora_xacml_api.install
+++ b/api/islandora_xacml_api.install
@@ -392,3 +392,16 @@ EOQ;
     ));
   }
 }
+
+/**
+ * Ensure RELS-INT relationships are present.
+ *
+ * @see https://jira.duraspace.org/browse/ISLANDORA-2067
+ */
+function islandora_xacml_api_update_7106(&$sandbox) {
+  if (!variable_get('islandora_xacml_api_save_relationships', TRUE)) {
+    return t('Relationships are disabled, nothing to do.');
+  }
+  drupal_set_message(t('Please run the islandora-xacml-api-relationships-missing-rels-int-batch drush command.'));
+  return t('Please run the islandora-xacml-api-relationships-missing-rels-int-batch command.');
+}

--- a/api/islandora_xacml_api.install
+++ b/api/islandora_xacml_api.install
@@ -400,7 +400,7 @@ EOQ;
  */
 function islandora_xacml_api_update_7106(&$sandbox) {
   if (!variable_get('islandora_xacml_api_save_relationships', TRUE)) {
-    return t('Relationships are disabled, nothing to do.');
+    return t('Relationships are disabled, if they were previously enabled it may be prudent to temporarily re-enable and run the isalndora-xacml-api-relationships-missing-rels-int-batch command to ensure consistency.');
   }
   drupal_set_message(t('Please run the islandora-xacml-api-relationships-missing-rels-int-batch drush command.'));
   return t('Please run the islandora-xacml-api-relationships-missing-rels-int-batch command.');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2067

# What does this Pull Request do?
Adds a Drush command that identifies potential inconsistencies in RELS-INT statements and XACML policies.

# What's new?
An update hook and a Drush command to identify and or fix RELS-INT statements that may be missing.

# How should this be tested?
Use the Tuque commit before https://github.com/Islandora/tuque/pull/161.
Create an XACML policy that specifies multiple datastream rules.
Run the Drush command as listed in the pull request and note that an inconsistency is identified and it fixes it.
Running the Drush command again does not find the object.

Example:
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  The Drush command needs to be ran so any potential broken POLICYs are fixed.
* Could this change impact execution of existing code? Makes broken POLICYs work as intended.

# Interested parties
@DiegoPino 
