### PR TITLE
ISLANDORA-2280: New Drush utilities

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -20,17 +20,19 @@
  *   Context array used in the batch.
  */
 function islandora_xacml_editor_batch_function($xml, $pid, $query_array, &$context) {
-  if (empty($context['sandbox'])) {
+  $sandbox = &$context['sandbox'];
+
+  if (!isset($sandbox['pids'])) {
     $query = new IslandoraXacmlEditorQuery($pid, $query_array);
-    $context['sandbox'] = array();
-    $context['sandbox']['progress'] = 0;
-    $context['sandbox']['pids'] = $query->getPids();
+    $sandbox['progress'] = 0;
+    $sandbox['pids'] = $query->getPids();
     $context['sandbox']['items'] = count($context['sandbox']['pids']);
     $context['results']['redirect'] = $pid;
     $context['results']['success'] = array();
     $context['results']['fail'] = array();
   }
   $targetpid = array_pop($context['sandbox']['pids']);
+
   $context['sandbox']['progress']++;
 
   $policy_update = new IslandoraUpdatePolicy($targetpid, $xml);

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -26,27 +26,33 @@ function islandora_xacml_editor_batch_function($xml, $pid, $query_array, &$conte
     $query = new IslandoraXacmlEditorQuery($pid, $query_array);
     $sandbox['progress'] = 0;
     $sandbox['pids'] = $query->getPids();
-    $context['sandbox']['items'] = count($context['sandbox']['pids']);
+    $sandbox['items'] = count($context['sandbox']['pids']);
     $context['results']['redirect'] = $pid;
     $context['results']['success'] = array();
     $context['results']['fail'] = array();
   }
-  $targetpid = array_pop($context['sandbox']['pids']);
 
-  $context['sandbox']['progress']++;
-
-  $policy_update = new IslandoraUpdatePolicy($targetpid, $xml);
-  $success = $policy_update->updatePolicy();
-
-  if ($success) {
-    $context['results']['success'][] = $targetpid;
+  if ($sandbox['items'] == 0) {
+    // If no items are found exit the operation.
+    $context['finished'] = 1;
   }
   else {
-    $context['results']['fail'][] = $targetpid;
-  }
+    $sandbox['progress']++;
 
-  // Make sure we don't divide by zero.
-  $context['finished'] = $context['sandbox']['items'] == 0 ? 1 : $context['sandbox']['progress'] / $context['sandbox']['items'];
+    $target_pid = array_pop($sandbox['pids']);
+
+    $policy_update = new IslandoraUpdatePolicy($target_pid, $xml);
+    $success = $policy_update->updatePolicy();
+
+    if ($success) {
+      $context['results']['success'][] = $target_pid;
+    }
+    else {
+      $context['results']['fail'][] = $target_pid;
+    }
+
+    $context['finished'] = $sandbox['progress'] / $sandbox['items'];
+  }
 }
 
 /**

--- a/islandora_xacml_editor.drush.inc
+++ b/islandora_xacml_editor.drush.inc
@@ -20,7 +20,7 @@ function islandora_xacml_editor_drush_command() {
     ),
     'options' => array(
       'policy' => array(
-        'description' => dt('The path to an XML file containing the XACML policy configuration to be applied.'),
+        'description' => dt('The path to an XML file containing the XACML policy configuration to be applied. It is expected that this policy file be generated from the UI\'s XACML Editor.'),
         'required' => TRUE,
       ),
       'pid' => array(
@@ -65,8 +65,7 @@ function drush_islandora_xacml_editor_apply_policy() {
   $object = islandora_object_load(drush_get_option('pid'));
 
   if (!$object) {
-    drush_log(dt('Error loading object.'), 'error');
-    return;
+    return drush_set_error('Invalid object', dt('An error occurred while trying to load \'@pid\'.', array('@pid' => drush_get_option('pid'))));
   }
 
   $policy = drush_get_option('policy');
@@ -75,13 +74,11 @@ function drush_islandora_xacml_editor_apply_policy() {
     $xml = file_get_contents($policy);
 
     if (!$xml) {
-      drush_log(dt('Could not read policy file at @policy', array('@policy' => $policy)), 'error');
-      return;
+      return drush_set_error('Failed to read file', dt('Could not read policy file from @policy', array('@policy' => $policy)));
     }
   }
   else {
-    drush_log(dt('File path provided does not exist or is not a file.'), 'error');
-    return;
+    return drush_set_error('Invalid policy parameter', dt('File path provided does not exist or is not a file.'));
   }
 
   $traversal = drush_get_option('traversal', FALSE);
@@ -102,21 +99,7 @@ function drush_islandora_xacml_editor_apply_policy() {
     }
   }
 
-  $batch = array(
-    'operations' => array(
-      array(
-        'islandora_xacml_editor_batch_function',
-        array($xml, $object->id, reset($query_array)),
-      ),
-    ),
-    'finished' => 'islandora_xacml_editor_batch_finished',
-    'file' => drupal_get_path('module', 'islandora_xacml_editor') . '/includes/batch.inc',
-  );
-
-  drush_log(dt('Please wait if many objects are being updated as this could take a few minutes.'), 'ok');
-
-  batch_set($batch);
-  drush_backend_batch_process();
+  islandora_xacml_editor_process_batch($xml, $object->id, reset($query_array));
 }
 
 /**
@@ -128,21 +111,18 @@ function drush_islandora_xacml_editor_force_policy_inheritance() {
   $object = islandora_object_load(drush_get_option('pid'));
 
   if (!$object) {
-    drush_log(dt('Error loading object.'), 'error');
-    return;
+    return drush_set_error('Error loading object', dt('An error occurred while trying to load \'@pid\'.', array('@pid' => drush_get_option('pid'))));
   }
 
   if ($object['POLICY']) {
     $xml = $object['POLICY']->content;
 
     if (!$xml) {
-      drush_log(dt('An error occurred while trying to load the \'POLICY\' for @pid.', array('@pid' => $object->id)), 'error');
-      return;
+      return drush_set_error('Failed to load policy', dt('An error occurred while trying to load the \'POLICY\' datastream for @pid.', array('@pid' => $object->id)));
     }
   }
   else {
-    drush_log(dt('No \'POLICY\' datastream found for @pid.', array('@pid' => $object->id)), 'error');
-    return;
+    return drush_set_error('No policy datastream', dt('No \'POLICY\' datastream found for @pid.', array('@pid' => $object->id)));
   }
 
   $query_array = array();
@@ -152,7 +132,6 @@ function drush_islandora_xacml_editor_force_policy_inheritance() {
 
     if (!empty($temp)) {
       $query_array = array_merge_recursive($query_array, $temp);
-
       // If shallow traversal is enabled and the content models child query
       // found targets all children, add the shallow restriction to the query.
       if (isset($query_array['all_children']) && drush_get_option('shallow_traversal', FALSE)) {
@@ -162,22 +141,35 @@ function drush_islandora_xacml_editor_force_policy_inheritance() {
   }
 
   if (empty($query_array)) {
-    drush_log('No child query found from object\'s content model.', 'error');
-    return;
+    return drush_set_error('No child query found', dt('No child query found for object\'s content model.'));
   }
 
+  islandora_xacml_editor_process_batch($xml, $object->id, reset($query_array));
+}
+
+/**
+ * Build and process batch operation.
+ *
+ * @param string $xml
+ *   String containing the XACML policy configuration markup.
+ * @param string $pid
+ *   The PID of the target object.
+ * @param array $query_array
+ *   Array containing query child query, type and description.
+ */
+function islandora_xacml_editor_process_batch($xml, $pid, array $query_array) {
   $batch = array(
     'operations' => array(
       array(
         'islandora_xacml_editor_batch_function',
-        array($xml, $object->id, reset($query_array)),
+        array($xml, $pid, $query_array),
       ),
     ),
     'finished' => 'islandora_xacml_editor_batch_finished',
     'file' => drupal_get_path('module', 'islandora_xacml_editor') . '/includes/batch.inc',
   );
 
-  drush_log(dt('Please wait if many objects are being updated as this could take a few minutes.'), 'ok');
+  drush_print(dt('Please wait if many objects are being updated as this could take a few minutes.'));
 
   batch_set($batch);
   drush_backend_batch_process();

--- a/islandora_xacml_editor.drush.inc
+++ b/islandora_xacml_editor.drush.inc
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @file
+ * Drush hooks.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function islandora_xacml_editor_drush_command() {
+  $items = array();
+
+  $items['islandora_xacml_editor_apply_policy'] = array(
+    'aliases' => array('ixeap'),
+    'description' => dt('Apply XACML policy to target object.'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+    'examples' => array(
+      'Apply policy.xml to \'islandora:57\', use traversal to target child objects.' => 'drush -v --user=1 islandora_xacml_editor_apply_policy --policy=/tmp/policy.xml --pid=islandora:57 --traversal',
+    ),
+    'options' => array(
+      'policy' => array(
+        'description' => dt('The path to an XML file containing the XACML policy configuration to be applied.'),
+        'required' => TRUE,
+      ),
+      'pid' => array(
+        'description' => dt('The PID of the object to apply the policy configuration to.'),
+        'required' => TRUE,
+      ),
+      'traversal' => array(
+        'description' => dt('Optional. Whether to apply policies to the target object\'s children (shallow traversal is not supported for collection objects). Disabled by default.'),
+        'required' => FALSE,
+      ),
+    ),
+  );
+
+  $items['islandora_xacml_editor_force_policy_inheritance'] = array(
+    'aliases' => array('ixefpi'),
+    'description' => dt('Force all child objects to inherit target object\'s XACML policy configuration.'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+    'examples' => array(
+      'Enforce policy inheritance to all immediate children of \'islandora:root\' object.' => 'drush -v --user=1 islandora_xacml_editor_force_policy_inheritance --pid=islandora:root --shallow_traversal',
+    ),
+    'options' => array(
+      'pid' => array(
+        'description' => dt('The PID of the parent object. Must have a \'POLICY\' datastream.'),
+        'required' => TRUE,
+      ),
+      'shallow_traversal' => array(
+        'description' => dt('Optional. If the target object is a collection, use shallow traversal to target only the immediate children. Disabled by default.'),
+        'required' => FALSE,
+      ),
+    ),
+  );
+
+  return $items;
+}
+
+/**
+ * Command callback to apply XACML policy.
+ */
+function drush_islandora_xacml_editor_apply_policy() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $object = islandora_object_load(drush_get_option('pid'));
+
+  if (!$object) {
+    drush_log(dt('Error loading object.'), 'error');
+    return;
+  }
+
+  $policy = drush_get_option('policy');
+
+  if (file_exists($policy) && is_file($policy)) {
+    $xml = file_get_contents($policy);
+
+    if (!$xml) {
+      drush_log(dt('Could not read policy file at @policy', array('@policy' => $policy)), 'error');
+      return;
+    }
+  }
+  else {
+    drush_log(dt('File path provided does not exist or is not a file.'), 'error');
+    return;
+  }
+
+  $traversal = drush_get_option('traversal', FALSE);
+
+  if ($traversal) {
+    $query_array = array();
+
+    foreach (islandora_build_hook_list('islandora_xacml_editor_child_query', $object->models) as $hook) {
+      $temp = module_invoke_all($hook, $object);
+
+      if (!empty($temp)) {
+        $query_array = array_merge_recursive($query_array, $temp);
+      }
+    }
+
+    if (empty($query_array)) {
+      drush_log('No child queries found, skipping traversal...', 'notice');
+    }
+  }
+
+  $batch = array(
+    'operations' => array(
+      array(
+        'islandora_xacml_editor_batch_function',
+        array($xml, $object->id, reset($query_array)),
+      ),
+    ),
+    'finished' => 'islandora_xacml_editor_batch_finished',
+    'file' => drupal_get_path('module', 'islandora_xacml_editor') . '/includes/batch.inc',
+  );
+
+  drush_log(dt('Please wait if many objects are being updated as this could take a few minutes.'), 'ok');
+
+  batch_set($batch);
+  drush_backend_batch_process();
+}
+
+/**
+ * Command callback to enforce XACML inheritance.
+ */
+function drush_islandora_xacml_editor_force_policy_inheritance() {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $object = islandora_object_load(drush_get_option('pid'));
+
+  if (!$object) {
+    drush_log(dt('Error loading object.'), 'error');
+    return;
+  }
+
+  if ($object['POLICY']) {
+    $xml = $object['POLICY']->content;
+
+    if (!$xml) {
+      drush_log(dt('An error occurred while trying to load the \'POLICY\' for @pid.', array('@pid' => $object->id)), 'error');
+      return;
+    }
+  }
+  else {
+    drush_log(dt('No \'POLICY\' datastream found for @pid.', array('@pid' => $object->id)), 'error');
+    return;
+  }
+
+  $query_array = array();
+
+  foreach (islandora_build_hook_list('islandora_xacml_editor_child_query', $object->models) as $hook) {
+    $temp = module_invoke_all($hook, $object);
+
+    if (!empty($temp)) {
+      $query_array = array_merge_recursive($query_array, $temp);
+
+      // If shallow traversal is enabled and the content models child query
+      // found targets all children, add the shallow restriction to the query.
+      if (isset($query_array['all_children']) && drush_get_option('shallow_traversal', FALSE)) {
+        $query_array['all_children']['restricted_cmodels'] = array('islandora:collectionCModel');
+      }
+    }
+  }
+
+  if (empty($query_array)) {
+    drush_log('No child query found from object\'s content model.', 'error');
+    return;
+  }
+
+  $batch = array(
+    'operations' => array(
+      array(
+        'islandora_xacml_editor_batch_function',
+        array($xml, $object->id, reset($query_array)),
+      ),
+    ),
+    'finished' => 'islandora_xacml_editor_batch_finished',
+    'file' => drupal_get_path('module', 'islandora_xacml_editor') . '/includes/batch.inc',
+  );
+
+  drush_log(dt('Please wait if many objects are being updated as this could take a few minutes.'), 'ok');
+
+  batch_set($batch);
+  drush_backend_batch_process();
+}

--- a/islandora_xacml_editor.drush.inc
+++ b/islandora_xacml_editor.drush.inc
@@ -16,7 +16,7 @@ function islandora_xacml_editor_drush_command() {
     'description' => dt('Apply XACML policy to target object.'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
     'examples' => array(
-      'Apply policy.xml to \'islandora:57\', use traversal to target child objects.' => 'drush -v --user=1 islandora_xacml_editor_apply_policy --policy=/tmp/policy.xml --pid=islandora:57 --traversal',
+      'Apply policy.xml to \'islandora:57\' and use traversal to target child objects.' => 'drush -v --user=1 islandora_xacml_editor_apply_policy --policy=/tmp/policy.xml --pid=islandora:57 --traversal',
     ),
     'options' => array(
       'policy' => array(
@@ -28,7 +28,7 @@ function islandora_xacml_editor_drush_command() {
         'required' => TRUE,
       ),
       'traversal' => array(
-        'description' => dt('Optional. Whether to apply policies to the target object\'s children (shallow traversal is not supported for collection objects). Disabled by default.'),
+        'description' => dt('Optional. When enabled, the policy configuration will be applied to the target object\'s children (shallow traversal is not supported for collection objects). Disabled by default.'),
         'required' => FALSE,
       ),
     ),

--- a/islandora_xacml_editor.drush.inc
+++ b/islandora_xacml_editor.drush.inc
@@ -91,15 +91,29 @@ function drush_islandora_xacml_editor_apply_policy() {
 
       if (!empty($temp)) {
         $query_array = array_merge_recursive($query_array, $temp);
+        // Need to reset the array as we expect only one query.
+        $query_array = reset($query_array);
       }
     }
 
     if (empty($query_array)) {
       drush_log('No child queries found, skipping traversal...', 'notice');
     }
-  }
 
-  islandora_xacml_editor_process_batch($xml, $object->id, reset($query_array));
+    islandora_xacml_editor_process_batch($xml, $object->id, $query_array);
+  }
+  else {
+    module_load_include('inc', 'islandora_xacml_editor', 'includes/batch');
+
+    $policy_update = new IslandoraUpdatePolicy($object->id, $xml);
+    $success = $policy_update->updatePolicy();
+
+    if (!$success) {
+      return drush_set_error('Failed to load policy', dt('An error occurred while trying to update the \'POLICY\' datastream for @pid.', array('@pid' => $object->id)));
+    }
+
+    drush_print(dt('The \'POLICY\' configuration has been applied to @pid!', array('@pid' => $object->id)));
+  }
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2280

# What does this Pull Request do?
Adds two new drush utilities:

* islandora_xacml_editor_apply_policy: a drush script which applies XACML policy configurations to a target object.

* islandora_xacml_editor_force_policy_inheritance: a drush script which enforces XACML inheritance to all children (shallow & deep traversal supported where possible).

Also fixed an issue with the batch implementations `$context` array being reset on every cycle for drush usage.

# What's new?
* New file: islandora_xacml_editor.drush.inc

# How should this be tested?
Aside from general test runs for both scripts:
* Test out different content models and ensure the traversal functions properly.
* Test out what could happen in the event a malformed Policy file passed into script.

# Additional Notes:
Perhaps an entry to the README should be added if this gets merged? I don't mind adding one.

# Interested parties
@Islandora/7-x-1-x-committers