### PR TITLE
Allow empty collections to set children policies - 2516

### DIFF
--- a/islandora_xacml_editor.module
+++ b/islandora_xacml_editor.module
@@ -127,16 +127,13 @@ select ?object from <#ri> WHERE
 }
 EOQ;
   $results = $object->repository->ri->sparqlQuery($collection_query);
-
-  if (count($results) > 0) {
-    return array(
-      'all_children' => array(
-        'type' => 'sparql',
-        'query' => $collection_query,
-        'description' => t('All children of this collection and collections within this collection (existing and new).'),
-      ),
-    );
-  }
+  return array(
+    'all_children' => array(
+      'type' => 'sparql',
+      'query' => $collection_query,
+      'description' => t('All children of this collection and collections within this collection (existing and new).'),
+    ),
+  );
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.lyrasis.org/browse/ISLANDORA-2516)

# What does this Pull Request do?

Allows management of XACML policies for children of an empty collection.

# What's new?

Simply removes the IF statement that prevents empty collections from showing the dropdown that determines how child objects' XACML policies are handled.

This is needed because you may wish to apply XACML policies to a collection that does not yet have children, and you need the same choices as for objects that already do have children. You need to ensure that new objects coming in are treated as you expect before they're actually ingested.

This should not have any deleterious effects.

# How should this be tested?

Ingest an empty collection and create a XACML policy for it. Try the different settings, and ingest new objects to confirm that they behave as expected.

# Interested parties
@Islandora/7-x-1-x-committers
